### PR TITLE
fix(artifacts/spec): tolerate YAML-style SPEC drift (#7)

### DIFF
--- a/src/agents/defaults/ba.md
+++ b/src/agents/defaults/ba.md
@@ -44,9 +44,9 @@ When the orchestrator's protocol asks you to emit the ready signal, do so on a l
 
 ## Canonical schemas (read before emitting)
 
-SPEC.md is **plain Markdown with `# SPEC` as the H1 and exactly six `## ` H2 sections, each containing only dash bullets and blank lines**. It is NOT YAML. Do not emit YAML keys (`goals:`, `users:`, `acceptance_criteria:`) with indented list values — the parser rejects them.
+SPEC.md is **plain Markdown with `# SPEC` as the H1 and exactly six `## ` H2 sections, each containing only dash bullets and blank lines**. The canonical contract is Markdown — emit Markdown, not YAML. The parser includes a narrow YAML-tolerance fallback for accidental drift, but you must produce canonical Markdown by default.
 
-Wrong (YAML-style — parser rejects):
+Wrong (YAML-style — emit canonical Markdown instead):
 
 ```
 # SPEC
@@ -66,7 +66,7 @@ explicit_non_goals:
   - Not building a name registry.
 ```
 
-Right (Markdown H2 sections — parser accepts):
+Right (Markdown H2 sections — canonical contract):
 
 ```
 # SPEC

--- a/src/agents/defaults/ba.md
+++ b/src/agents/defaults/ba.md
@@ -42,4 +42,68 @@ Stop asking when you can answer all six SPEC sections concretely:
 
 When the orchestrator's protocol asks you to emit the ready signal, do so on a line by itself, then produce the complete SPEC.md draft in the canonical format. The orchestrator validates the draft structurally before writing it.
 
+## Canonical schemas (read before emitting)
+
+SPEC.md is **plain Markdown with `# SPEC` as the H1 and exactly six `## ` H2 sections, each containing only dash bullets and blank lines**. It is NOT YAML. Do not emit YAML keys (`goals:`, `users:`, `acceptance_criteria:`) with indented list values — the parser rejects them.
+
+Wrong (YAML-style — parser rejects):
+
+```
+# SPEC
+
+goals:
+  - Help a parent name their newborn.
+  - Suggest names balanced across given-name and surname pairings.
+users:
+  - New parents with a fixed surname.
+constraints:
+  - Runs locally on a phone-class device.
+acceptance_criteria:
+  - Given a surname, the app produces 5 candidate given names.
+open_questions:
+  - Does the parent want gender-neutral suggestions only?
+explicit_non_goals:
+  - Not building a name registry.
+```
+
+Right (Markdown H2 sections — parser accepts):
+
+```
+# SPEC
+
+## Goals
+
+- Help a parent name their newborn.
+- Suggest names balanced across given-name and surname pairings.
+
+## Users
+
+- New parents with a fixed surname.
+
+## Constraints
+
+- Runs locally on a phone-class device.
+
+## Acceptance criteria
+
+- Given a surname, the app produces 5 candidate given names.
+
+## Open questions
+
+- Does the parent want gender-neutral suggestions only?
+
+## Explicit non-goals
+
+- Not building a name registry.
+```
+
+Required SPEC.md rules:
+
+- H1 form: `# SPEC` (exact spelling, exact case).
+- Six required H2 sections in this canonical order: `## Goals`, `## Users`, `## Constraints`, `## Acceptance criteria`, `## Open questions`, `## Explicit non-goals`. Spelling and case must match exactly.
+- Each section body contains only `- bullet` lines and blank lines. No paragraphs, no sub-headings, no code fences.
+- Each section needs ≥ 1 bullet.
+- When there are no open questions, emit the canonical sentinel as the only bullet: `- None known at define time.`
+- No content before `# SPEC` and no content between `# SPEC` and the first `## ` section heading.
+
 The DEFINE gate file (`state/GATE_DEFINE_PASSED.json`) is written by the user via `code-oz approve define` after they review SPEC.md. Never claim gate signoff.

--- a/src/artifacts/spec.ts
+++ b/src/artifacts/spec.ts
@@ -105,6 +105,7 @@ const YAML_SPEC_KEY_MAP: Readonly<Record<string, string>> = Object.freeze({
   explicit_non_goals: 'Explicit non-goals',
   explicitnongoals: 'Explicit non-goals',
   'explicit-non-goals': 'Explicit non-goals',
+  'non goals': 'Explicit non-goals',
   nongoals: 'Explicit non-goals',
   non_goals: 'Explicit non-goals',
   'non-goals': 'Explicit non-goals',
@@ -123,14 +124,49 @@ function normalizeSpecKey(raw: string): string | null {
   return YAML_SPEC_KEY_MAP[folded] ?? null
 }
 
+// Quote-aware comma splitter: splits on top-level commas only, respecting
+// single- and double-quoted scalars. `'a, b', c` -> ['\'a, b\'', ' c']
+// rather than the naive 3-way split. Required to honour the "rewrite shape,
+// not semantics" boundary — naive split on `["a, b", c]` would silently
+// turn one quoted scalar into two accepted bullets (Codex review block-push
+// finding on PR #10).
+function splitTopLevelCommas(s: string): string[] {
+  const out: string[] = []
+  let current = ''
+  let inSingle = false
+  let inDouble = false
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]!
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble
+      current += ch
+      continue
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle
+      current += ch
+      continue
+    }
+    if (ch === ',' && !inSingle && !inDouble) {
+      out.push(current)
+      current = ''
+      continue
+    }
+    current += ch
+  }
+  if (current.length > 0) out.push(current)
+  return out
+}
+
 function parseInlineList(value: string): string[] {
   // Accepts `[a, b, c]` flow-style YAML or comma-separated bare values.
+  // Splits on top-level commas only — quoted scalars containing commas are
+  // preserved as single items.
   const trimmed = value.trim()
   if (trimmed.length === 0) return []
   const flow = trimmed.match(/^\[(.*)\]$/)
   const inner = flow !== null ? flow[1]! : trimmed
-  return inner
-    .split(',')
+  return splitTopLevelCommas(inner)
     .map((s) => s.trim().replace(/^["']|["']$/g, ''))
     .filter((s) => s.length > 0)
 }
@@ -198,8 +234,21 @@ export function adaptYamlStyleSpec(raw: string): string {
       if (!/^[ \t]/.test(cont)) break
       const indented = cont.match(/^[ \t]+-\s*(.*)$/)
       if (indented === null) {
-        // Indented continuation that isn't a bullet — drop it; the strict
-        // parser would have rejected the same content anyway.
+        // Indented continuation that isn't a `- bullet` — folded YAML
+        // continuation (the next-line text of a multi-line scalar). Append
+        // the trimmed text to the previous bullet so the author's content
+        // is preserved instead of silently dropped (Codex review block-push
+        // finding on PR #10). If there is no previous bullet (the YAML key
+        // had no inline value and no prior bullet), push the text as its
+        // own bullet — unusual but better than silent data loss.
+        const trimmedCont = cont.trim()
+        if (trimmedCont.length > 0) {
+          if (bullets.length > 0) {
+            bullets[bullets.length - 1] = `${bullets[bullets.length - 1]} ${trimmedCont}`
+          } else {
+            bullets.push(trimmedCont)
+          }
+        }
         i++
         continue
       }

--- a/src/artifacts/spec.ts
+++ b/src/artifacts/spec.ts
@@ -64,6 +64,157 @@ export interface SpecArtifact {
   readonly nonGoals: readonly string[]
 }
 
+// --- YAML-style tolerance (issue #7) -------------------------------
+
+// LLMs occasionally emit SPEC.md as YAML — a top-level key per section
+// (`goals:` / `users:` / `acceptance_criteria:`) with indented `- bullet`
+// list values — instead of the canonical `## Heading\n\n- bullet` H2-block
+// schema. Tolerance scope: GitHub issue #7 — same drift class as #5
+// (HYPOTHESES) and #3 (SOURCE_CHECK REF-NONE) but on the DEFINE-phase
+// artifact, where any failure crashes the very first phase. We pre-rewrite
+// YAML key/list pairs into canonical Markdown sections before strict parsing
+// so the artifact validates instead of failing the DEFINE preview.
+//
+// Discipline boundary: the adapter fires ONLY on lines that start at column 0
+// and match a recognised SPEC section key (case-insensitive) followed by a
+// colon and end-of-line, and only when followed by indented `- bullet` lines
+// or YAML-style flow lists. Canonical `## Heading` blocks pass through
+// untouched, so mixed-format input (some YAML, some canonical) works. The
+// strict parser still owns final validation; an unrecognised top-level key
+// falls through to the strict parser's `spec_unexpected_content` error.
+
+// Key normalisation map: every recognised input key (case folded) maps to its
+// canonical section heading. Aliases (snake_case / camelCase / kebab-case /
+// abbreviated forms) all collapse to the same SpecSectionKey-equivalent
+// heading the strict parser understands.
+const YAML_SPEC_KEY_MAP: Readonly<Record<string, string>> = Object.freeze({
+  goals: 'Goals',
+  users: 'Users',
+  constraints: 'Constraints',
+  'acceptance criteria': 'Acceptance criteria',
+  acceptance_criteria: 'Acceptance criteria',
+  acceptancecriteria: 'Acceptance criteria',
+  'acceptance-criteria': 'Acceptance criteria',
+  acceptance: 'Acceptance criteria',
+  'open questions': 'Open questions',
+  open_questions: 'Open questions',
+  openquestions: 'Open questions',
+  'open-questions': 'Open questions',
+  'explicit non-goals': 'Explicit non-goals',
+  'explicit non goals': 'Explicit non-goals',
+  explicit_non_goals: 'Explicit non-goals',
+  explicitnongoals: 'Explicit non-goals',
+  'explicit-non-goals': 'Explicit non-goals',
+  nongoals: 'Explicit non-goals',
+  non_goals: 'Explicit non-goals',
+  'non-goals': 'Explicit non-goals',
+})
+
+// Probe: column-0 line starting with a recognised SPEC section key followed
+// by a colon, with no leading `## ` Markdown heading marker. Matches every
+// alias spelling in YAML_SPEC_KEY_MAP via a single regex so we can short
+// circuit when the input is already canonical Markdown.
+const YAML_SPEC_KEY_PROBE = /^(?:goals|users|constraints|acceptance(?:[ _-]?criteria)?|open[ _-]?questions|(?:explicit[ _-])?non[ _-]?goals):\s*(?:\[.*\])?\s*$/im
+
+const YAML_SPEC_KEY_LINE = /^([A-Za-z][A-Za-z _-]*?):\s*(.*)$/
+
+function normalizeSpecKey(raw: string): string | null {
+  const folded = raw.trim().toLowerCase()
+  return YAML_SPEC_KEY_MAP[folded] ?? null
+}
+
+function parseInlineList(value: string): string[] {
+  // Accepts `[a, b, c]` flow-style YAML or comma-separated bare values.
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return []
+  const flow = trimmed.match(/^\[(.*)\]$/)
+  const inner = flow !== null ? flow[1]! : trimmed
+  return inner
+    .split(',')
+    .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+    .filter((s) => s.length > 0)
+}
+
+/**
+ * Pre-parse adapter: rewrite YAML-style SPEC blocks (top-level
+ * `goals:` / `users:` / etc. keys with indented `- bullet` list values or
+ * inline flow lists) into canonical `## Heading\n\n- bullet` Markdown
+ * sections. Returns the input unchanged if no YAML markers are present.
+ *
+ * Issue #7 tolerance. Mixed-format input is supported — canonical `## `
+ * sections pass through verbatim; only YAML key/list pairs are rewritten.
+ *
+ * The adapter is intentionally narrow: it does not rewrite arbitrary YAML
+ * structure (only the recognised SPEC section keys), it does not invent
+ * sentinel content for empty sections (the strict parser surfaces that), and
+ * it preserves the canonical `# SPEC` H1 untouched.
+ */
+export function adaptYamlStyleSpec(raw: string): string {
+  if (!YAML_SPEC_KEY_PROBE.test(raw)) return raw
+  const lines = raw.split(/\r?\n/)
+  const out: string[] = []
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]!
+    // Only rewrite lines at column 0 that match a recognised key. Anything
+    // else (canonical headings, bullets, blank lines, the H1) passes through.
+    if (/^[ \t]/.test(line) || line.length === 0 || line.startsWith('#')) {
+      out.push(line)
+      i++
+      continue
+    }
+    const keyMatch = line.match(YAML_SPEC_KEY_LINE)
+    if (keyMatch === null) {
+      out.push(line)
+      i++
+      continue
+    }
+    const heading = normalizeSpecKey(keyMatch[1]!)
+    if (heading === null) {
+      out.push(line)
+      i++
+      continue
+    }
+    const inlineValue = keyMatch[2]!.trim()
+    const bullets: string[] = []
+    if (inlineValue.length > 0) {
+      // Inline flow list (`goals: [a, b]`) or single bare value (`goals: only goal`).
+      bullets.push(...parseInlineList(inlineValue))
+    }
+    i++
+    // Collect indented `- bullet` continuations until a column-0 line.
+    // Blank lines inside the list are tolerated when the following non-blank
+    // line is still indented; otherwise the section ends.
+    while (i < lines.length) {
+      const cont = lines[i]!
+      if (cont.length === 0) {
+        let j = i + 1
+        while (j < lines.length && lines[j]!.length === 0) j++
+        if (j >= lines.length) break
+        if (!/^[ \t]+/.test(lines[j]!)) break
+        i++
+        continue
+      }
+      if (!/^[ \t]/.test(cont)) break
+      const indented = cont.match(/^[ \t]+-\s*(.*)$/)
+      if (indented === null) {
+        // Indented continuation that isn't a bullet — drop it; the strict
+        // parser would have rejected the same content anyway.
+        i++
+        continue
+      }
+      const bullet = indented[1]!.trim()
+      if (bullet.length > 0) bullets.push(bullet)
+      i++
+    }
+    out.push(`## ${heading}`)
+    out.push('')
+    for (const b of bullets) out.push(`- ${b}`)
+    out.push('')
+  }
+  return out.join('\n')
+}
+
 // --- parser --------------------------------------------------------
 
 const BOM = '﻿'
@@ -82,7 +233,8 @@ interface SectionBuf {
  */
 export function parseSpec(raw: string, file = 'SPEC.md'): SpecArtifact {
   const issues: SpecLoadIssue[] = []
-  const text = raw.startsWith(BOM) ? raw.slice(BOM.length) : raw
+  const adapted = adaptYamlStyleSpec(raw)
+  const text = adapted.startsWith(BOM) ? adapted.slice(BOM.length) : adapted
 
   if (text.trim().length === 0) {
     throw new SpecLoadError([

--- a/src/artifacts/spec.ts
+++ b/src/artifacts/spec.ts
@@ -115,7 +115,10 @@ const YAML_SPEC_KEY_MAP: Readonly<Record<string, string>> = Object.freeze({
 // by a colon, with no leading `## ` Markdown heading marker. Matches every
 // alias spelling in YAML_SPEC_KEY_MAP via a single regex so we can short
 // circuit when the input is already canonical Markdown.
-const YAML_SPEC_KEY_PROBE = /^(?:goals|users|constraints|acceptance(?:[ _-]?criteria)?|open[ _-]?questions|(?:explicit[ _-])?non[ _-]?goals):\s*(?:\[.*\])?\s*$/im
+// The `[ _-]?` after `explicit` is optional so the probe matches
+// concatenated forms like `explicitnongoals` and `explicitNonGoals`
+// (which the map already accepts) — closes a round-2 fix-soon asymmetry.
+const YAML_SPEC_KEY_PROBE = /^(?:goals|users|constraints|acceptance(?:[ _-]?criteria)?|open[ _-]?questions|(?:explicit[ _-]?)?non[ _-]?goals):\s*(?:\[.*\])?\s*$/im
 
 const YAML_SPEC_KEY_LINE = /^([A-Za-z][A-Za-z _-]*?):\s*(.*)$/
 
@@ -125,11 +128,12 @@ function normalizeSpecKey(raw: string): string | null {
 }
 
 // Quote-aware comma splitter: splits on top-level commas only, respecting
-// single- and double-quoted scalars. `'a, b', c` -> ['\'a, b\'', ' c']
-// rather than the naive 3-way split. Required to honour the "rewrite shape,
-// not semantics" boundary — naive split on `["a, b", c]` would silently
-// turn one quoted scalar into two accepted bullets (Codex review block-push
-// finding on PR #10).
+// single- and double-quoted scalars and backslash escapes inside them.
+// `'a, b', c` -> ['\'a, b\'', ' c']; `"\"yes, now\""` stays intact instead
+// of toggling quote state on the escaped quote. Required to honour the
+// "rewrite shape, not semantics" boundary — naive split would silently
+// turn one quoted scalar into multiple accepted bullets (Codex review
+// block-push findings, rounds 1 and 2, on PR #10).
 function splitTopLevelCommas(s: string): string[] {
   const out: string[] = []
   let current = ''
@@ -137,6 +141,14 @@ function splitTopLevelCommas(s: string): string[] {
   let inDouble = false
   for (let i = 0; i < s.length; i++) {
     const ch = s[i]!
+    // Backslash escape — preserve verbatim, don't toggle quote state.
+    // Honors `\"` inside double-quoted scalars and `\'` inside single-quoted
+    // scalars; the escaped char passes through to the bullet text untouched.
+    if (ch === '\\' && i + 1 < s.length) {
+      current += ch + s[i + 1]
+      i++
+      continue
+    }
     if (ch === '"' && !inSingle) {
       inDouble = !inDouble
       current += ch
@@ -211,6 +223,7 @@ export function adaptYamlStyleSpec(raw: string): string {
       i++
       continue
     }
+    const keyLineIdx = i
     const inlineValue = keyMatch[2]!.trim()
     const bullets: string[] = []
     if (inlineValue.length > 0) {
@@ -219,8 +232,21 @@ export function adaptYamlStyleSpec(raw: string): string {
     }
     i++
     // Collect indented `- bullet` continuations until a column-0 line.
-    // Blank lines inside the list are tolerated when the following non-blank
-    // line is still indented; otherwise the section ends.
+    // Three rejection conditions abort this YAML block's rewrite — the
+    // collected lines are restored verbatim so the strict parser surfaces
+    // them rather than silently flattening them into bullets:
+    //
+    //   1. Nested YAML key (indented `key: value` line, no leading `-`)
+    //      indicates a nested map structure the section-level adapter
+    //      cannot safely rewrite.
+    //   2. Deeper-indented `- bullet` (indent > the first bullet's indent)
+    //      indicates a nested list, same reason.
+    //
+    // Otherwise indented non-bullet text is treated as a folded YAML
+    // continuation and appended to the previous bullet (Codex review
+    // block-push findings, rounds 1 and 2, on PR #10).
+    let firstBulletIndent = -1
+    let abortRewrite = false
     while (i < lines.length) {
       const cont = lines[i]!
       if (cont.length === 0) {
@@ -232,29 +258,50 @@ export function adaptYamlStyleSpec(raw: string): string {
         continue
       }
       if (!/^[ \t]/.test(cont)) break
+      // Reject nested YAML key (indented `key:` with no leading `-`).
+      if (/^[ \t]+[A-Za-z][A-Za-z0-9_-]*\s*:\s*/.test(cont) && !/^[ \t]+-\s/.test(cont)) {
+        abortRewrite = true
+        break
+      }
       const indented = cont.match(/^[ \t]+-\s*(.*)$/)
-      if (indented === null) {
-        // Indented continuation that isn't a `- bullet` — folded YAML
-        // continuation (the next-line text of a multi-line scalar). Append
-        // the trimmed text to the previous bullet so the author's content
-        // is preserved instead of silently dropped (Codex review block-push
-        // finding on PR #10). If there is no previous bullet (the YAML key
-        // had no inline value and no prior bullet), push the text as its
-        // own bullet — unusual but better than silent data loss.
-        const trimmedCont = cont.trim()
-        if (trimmedCont.length > 0) {
-          if (bullets.length > 0) {
-            bullets[bullets.length - 1] = `${bullets[bullets.length - 1]} ${trimmedCont}`
-          } else {
-            bullets.push(trimmedCont)
-          }
+      if (indented !== null) {
+        const bulletIndent = cont.search(/[^ \t]/)
+        if (firstBulletIndent === -1) {
+          firstBulletIndent = bulletIndent
+        } else if (bulletIndent > firstBulletIndent) {
+          // Reject deeper-indent bullet (nested list).
+          abortRewrite = true
+          break
+        } else if (bulletIndent < firstBulletIndent) {
+          // Shallower indent — section ended.
+          break
         }
+        const bullet = indented[1]!.trim()
+        if (bullet.length > 0) bullets.push(bullet)
         i++
         continue
       }
-      const bullet = indented[1]!.trim()
-      if (bullet.length > 0) bullets.push(bullet)
+      // Folded continuation (indented text with no `-` and no `:`).
+      // Append the trimmed text to the previous bullet so the author's
+      // content is preserved instead of silently dropped. If there is no
+      // previous bullet, push the text as its own bullet (unusual; YAML
+      // key with continuation but no leading `-`).
+      const trimmedCont = cont.trim()
+      if (trimmedCont.length > 0) {
+        if (bullets.length > 0) {
+          bullets[bullets.length - 1] = `${bullets[bullets.length - 1]} ${trimmedCont}`
+        } else {
+          bullets.push(trimmedCont)
+        }
+      }
       i++
+    }
+    if (abortRewrite) {
+      // Emit the original key line + collected lines verbatim. The strict
+      // parser will surface the unrewritten YAML structure rather than
+      // accepting a flattened form that drops nesting.
+      for (let j = keyLineIdx; j < i; j++) out.push(lines[j]!)
+      continue
     }
     out.push(`## ${heading}`)
     out.push('')

--- a/tests/artifacts-spec.test.ts
+++ b/tests/artifacts-spec.test.ts
@@ -767,3 +767,178 @@ non_goals:
     expect(spec.goals).toEqual(['g'])
   })
 })
+
+describe('adaptYamlStyleSpec — Codex round-2 regressions', () => {
+  test('escaped double quote in flow scalar does not corrupt comma split', () => {
+    // `["say \"yes, now\"", second]` previously toggled quote state on the
+    // escaped `"` and split at the inner comma, yielding 3 bullets. The
+    // backslash-escape path now preserves quote state, leaving the scalar
+    // intact (Codex round-2 block-push finding).
+    const yaml = `# SPEC
+
+goals: ["say \\"yes, now\\"", "second"]
+
+users:
+  - U
+
+constraints:
+  - C
+
+acceptance:
+  - A
+
+open_questions:
+  - Q
+
+non_goals:
+  - NG
+`
+    const spec = parseSpec(yaml)
+    expect(spec.goals.length).toBe(2)
+    // The escaped quote stays in the bullet text (we rewrite shape, not
+    // semantics — leaving \" verbatim is acceptable).
+    expect(spec.goals[0]).toContain('yes, now')
+    expect(spec.goals[1]).toBe('second')
+  })
+
+  test('escaped single quote in flow scalar does not corrupt comma split', () => {
+    const yaml = `# SPEC
+
+goals: ['don\\'t, please', 'second']
+
+users:
+  - U
+
+constraints:
+  - C
+
+acceptance:
+  - A
+
+open_questions:
+  - Q
+
+non_goals:
+  - NG
+`
+    const spec = parseSpec(yaml)
+    expect(spec.goals.length).toBe(2)
+    expect(spec.goals[0]).toContain('don')
+    expect(spec.goals[0]).toContain('please')
+    expect(spec.goals[1]).toBe('second')
+  })
+
+  test('nested YAML map under a section key is rejected, not flattened', () => {
+    // `goals:\n  - first\n    nested:\n      - sub1` previously folded
+    // `nested:` and `- sub1` into the prior bullet. The adapter now aborts
+    // the rewrite of this YAML block and lets the strict parser reject the
+    // nested structure (Codex round-2 block-push finding).
+    const yaml = `# SPEC
+
+goals:
+  - first
+    nested:
+      - sub1
+
+users:
+  - U
+
+constraints:
+  - C
+
+acceptance:
+  - A
+
+open_questions:
+  - Q
+
+non_goals:
+  - NG
+`
+    expect(() => parseSpec(yaml)).toThrow()
+  })
+
+  test('nested list (deeper indent bullet) is rejected, not folded', () => {
+    const yaml = `# SPEC
+
+goals:
+  - first
+    - nested-item-deeper-indent
+
+users:
+  - U
+
+constraints:
+  - C
+
+acceptance:
+  - A
+
+open_questions:
+  - Q
+
+non_goals:
+  - NG
+`
+    expect(() => parseSpec(yaml)).toThrow()
+  })
+
+  test('explicitnongoals (concatenated, no separator) probe matches and resolves', () => {
+    // Probe was previously `(?:explicit[ _-])?non[ _-]?goals` — required a
+    // separator after `explicit`, so `explicitnongoals:` skipped the
+    // adapter even though the map accepted it. The optional separator now
+    // closes the asymmetry (Codex round-2 fix-soon).
+    const yaml = `# SPEC
+
+goals:
+  - g
+
+users:
+  - u
+
+constraints:
+  - c
+
+acceptance:
+  - a
+
+open_questions:
+  - q
+
+explicitnongoals:
+  - ng
+`
+    const spec = parseSpec(yaml)
+    expect(spec.nonGoals).toEqual(['ng'])
+  })
+
+  test('round-trip: YAML flow list with comma scalar serialize → reparse stable', () => {
+    // Codex round-2 fix-soon: confirm a goal containing a comma round-trips
+    // through serialize → reparse without splitting.
+    const yaml = `# SPEC
+
+goals: ["a, b", c]
+
+users:
+  - U
+
+constraints:
+  - C
+
+acceptance:
+  - A
+
+open_questions:
+  - Q
+
+non_goals:
+  - NG
+`
+    const spec = parseSpec(yaml)
+    expect(spec.goals).toEqual(['a, b', 'c'])
+    const serialized = serializeSpec(spec)
+    expect(serialized).toContain('- a, b')
+    const reparsed = parseSpec(serialized)
+    expect(reparsed.goals).toEqual(['a, b', 'c'])
+  })
+})

--- a/tests/artifacts-spec.test.ts
+++ b/tests/artifacts-spec.test.ts
@@ -3,6 +3,7 @@ import {
   parseSpec,
   serializeSpec,
   hasMinimumContent,
+  adaptYamlStyleSpec,
   SPEC_OPEN_QUESTIONS_NONE,
   SPEC_SECTION_KEYS,
   type SpecArtifact,
@@ -358,5 +359,251 @@ describe('SPEC_SECTION_KEYS', () => {
       'openQuestions',
       'nonGoals',
     ])
+  })
+})
+
+// --- issue #7: YAML-style SPEC tolerance ---------------------------
+
+const YAML_SPEC = `# SPEC
+
+goals:
+  - Help a parent name their newborn.
+  - Suggest names balanced across given-name and surname pairings.
+
+users:
+  - New parents with a fixed surname.
+
+constraints:
+  - Runs locally on a phone-class device.
+
+acceptance_criteria:
+  - Given a surname, the app produces 5 candidate given names.
+
+open_questions:
+  - Does the parent want gender-neutral suggestions only?
+
+explicit_non_goals:
+  - Not building a name registry.
+`
+
+describe('adaptYamlStyleSpec (issue #7)', () => {
+  test('returns input unchanged when no YAML markers are present', () => {
+    expect(adaptYamlStyleSpec(VALID)).toBe(VALID)
+  })
+
+  test('returns input unchanged for empty / pre-title content', () => {
+    expect(adaptYamlStyleSpec('')).toBe('')
+    expect(adaptYamlStyleSpec('# SPEC\n')).toBe('# SPEC\n')
+  })
+
+  test('rewrites YAML keys to canonical H2 headings', () => {
+    const out = adaptYamlStyleSpec(YAML_SPEC)
+    expect(out).toContain('## Goals')
+    expect(out).toContain('## Users')
+    expect(out).toContain('## Constraints')
+    expect(out).toContain('## Acceptance criteria')
+    expect(out).toContain('## Open questions')
+    expect(out).toContain('## Explicit non-goals')
+  })
+
+  test('strips YAML key markers after rewrite', () => {
+    const out = adaptYamlStyleSpec(YAML_SPEC)
+    // Top-level YAML keys are replaced with H2 sections; only `# SPEC` remains
+    // as a non-bullet column-0 line.
+    const columnZeroLines = out.split('\n').filter((l) => l.length > 0 && !/^[ \t]/.test(l))
+    for (const line of columnZeroLines) {
+      expect(line.startsWith('# ') || line.startsWith('## ') || line.startsWith('- ')).toBe(true)
+    }
+  })
+
+  test('preserves bullet content from indented YAML lists', () => {
+    const out = adaptYamlStyleSpec(YAML_SPEC)
+    expect(out).toContain('- Help a parent name their newborn.')
+    expect(out).toContain('- Suggest names balanced across given-name and surname pairings.')
+    expect(out).toContain('- Given a surname, the app produces 5 candidate given names.')
+  })
+
+  test('normalises snake_case / camelCase / kebab-case key aliases', () => {
+    const variants = `# SPEC
+
+Goals:
+  - g
+
+users:
+  - u
+
+CONSTRAINTS:
+  - c
+
+acceptanceCriteria:
+  - a
+
+open-questions:
+  - q
+
+nonGoals:
+  - ng
+`
+    const out = adaptYamlStyleSpec(variants)
+    expect(out).toContain('## Goals')
+    expect(out).toContain('## Users')
+    expect(out).toContain('## Constraints')
+    expect(out).toContain('## Acceptance criteria')
+    expect(out).toContain('## Open questions')
+    expect(out).toContain('## Explicit non-goals')
+  })
+
+  test('accepts inline flow-list values (`goals: [a, b]`)', () => {
+    const flow = `# SPEC
+
+goals: [first goal, second goal]
+
+users:
+  - U
+
+constraints:
+  - C
+
+acceptance:
+  - A
+
+open_questions:
+  - Q
+
+non_goals:
+  - NG
+`
+    const out = adaptYamlStyleSpec(flow)
+    expect(out).toContain('- first goal')
+    expect(out).toContain('- second goal')
+  })
+
+  test('handles mixed format (one canonical section, one YAML key)', () => {
+    const mixed = `# SPEC
+
+## Goals
+
+- Canonical bullet stays.
+
+users:
+  - YAML user gets rewritten.
+
+constraints:
+  - C
+
+acceptance:
+  - A
+
+open_questions:
+  - Q
+
+non_goals:
+  - NG
+`
+    const spec = parseSpec(mixed)
+    expect(spec.goals).toEqual(['Canonical bullet stays.'])
+    expect(spec.users).toEqual(['YAML user gets rewritten.'])
+  })
+})
+
+describe('parseSpec — issue #7 YAML tolerance', () => {
+  test('parses pure-YAML input end-to-end', () => {
+    const spec = parseSpec(YAML_SPEC)
+    expect(spec.title).toBe('SPEC')
+    expect(spec.goals.length).toBe(2)
+    expect(spec.users.length).toBe(1)
+    expect(spec.constraints.length).toBe(1)
+    expect(spec.acceptance.length).toBe(1)
+    expect(spec.openQuestions.length).toBe(1)
+    expect(spec.nonGoals.length).toBe(1)
+    expect(spec.acceptance[0]).toContain('5 candidate given names')
+  })
+
+  test('round-trips YAML through serialize → reparse to canonical', () => {
+    const spec = parseSpec(YAML_SPEC)
+    const serialized = serializeSpec(spec)
+    expect(serialized).toContain('## Goals')
+    expect(serialized).not.toMatch(/^goals:/m)
+    const reparsed = parseSpec(serialized)
+    expect(reparsed.goals).toEqual(spec.goals)
+    expect(reparsed.acceptance).toEqual(spec.acceptance)
+    expect(reparsed.nonGoals).toEqual(spec.nonGoals)
+  })
+
+  test('still rejects YAML missing a section (tolerance does not invent sections)', () => {
+    const incomplete = `# SPEC
+
+goals:
+  - g
+
+users:
+  - u
+
+constraints:
+  - c
+
+acceptance:
+  - a
+
+open_questions:
+  - q
+`
+    // Missing explicit_non_goals — strict parser must still surface this.
+    const err = expectSpecLoadError(() => parseSpec(incomplete))
+    expect(err.issues.some((i) => i.code === 'spec_missing_section')).toBe(true)
+  })
+
+  test('still rejects unknown YAML keys via strict parser passthrough', () => {
+    const unknown = `# SPEC
+
+mystery_field:
+  - x
+
+goals:
+  - g
+
+users:
+  - u
+
+constraints:
+  - c
+
+acceptance:
+  - a
+
+open_questions:
+  - q
+
+non_goals:
+  - ng
+`
+    // Unknown YAML keys remain as column-0 `mystery_field:` lines and reach
+    // the strict parser's content guards.
+    expect(() => parseSpec(unknown)).toThrow()
+  })
+
+  test('accepts YAML with empty open_questions sentinel', () => {
+    const withSentinel = `# SPEC
+
+goals:
+  - g
+
+users:
+  - u
+
+constraints:
+  - c
+
+acceptance:
+  - a
+
+open_questions:
+  - ${SPEC_OPEN_QUESTIONS_NONE.slice(2)}
+
+non_goals:
+  - ng
+`
+    const spec = parseSpec(withSentinel)
+    expect(spec.openQuestions).toEqual([SPEC_OPEN_QUESTIONS_NONE.slice(2)])
   })
 })

--- a/tests/artifacts-spec.test.ts
+++ b/tests/artifacts-spec.test.ts
@@ -607,3 +607,163 @@ non_goals:
     expect(spec.openQuestions).toEqual([SPEC_OPEN_QUESTIONS_NONE.slice(2)])
   })
 })
+
+describe('adaptYamlStyleSpec — Codex review block-push regressions', () => {
+  test('flow list with quoted comma keeps the scalar intact', () => {
+    // Naive split-on-comma would turn one quoted scalar into two bullets.
+    // Quote-aware splitter must preserve `"a, b"` as a single bullet.
+    const yaml = `# SPEC
+
+goals: ["first goal, with comma", "second goal"]
+
+users:
+  - U
+
+constraints:
+  - C
+
+acceptance:
+  - A
+
+open_questions:
+  - Q
+
+non_goals:
+  - NG
+`
+    const spec = parseSpec(yaml)
+    expect(spec.goals).toEqual(['first goal, with comma', 'second goal'])
+  })
+
+  test('flow list with single-quoted comma keeps the scalar intact', () => {
+    const yaml = `# SPEC
+
+goals: ['a, b', c]
+
+users:
+  - U
+
+constraints:
+  - C
+
+acceptance:
+  - A
+
+open_questions:
+  - Q
+
+non_goals:
+  - NG
+`
+    const spec = parseSpec(yaml)
+    expect(spec.goals).toEqual(['a, b', 'c'])
+  })
+
+  test('flow list with trailing comma drops empty trailing item', () => {
+    const yaml = `# SPEC
+
+goals: [a, b, c, ]
+
+users:
+  - U
+
+constraints:
+  - C
+
+acceptance:
+  - A
+
+open_questions:
+  - Q
+
+non_goals:
+  - NG
+`
+    const spec = parseSpec(yaml)
+    expect(spec.goals).toEqual(['a', 'b', 'c'])
+  })
+
+  test('YAML continuation line is folded onto previous bullet, not dropped', () => {
+    // A folded multi-line scalar (`- First line\n    continuation`) must
+    // preserve the continuation text. Silently dropping it would corrupt
+    // author intent — the very class of bug issue #7 is fixing.
+    const yaml = `# SPEC
+
+goals:
+  - First goal line one
+    continuation of first goal
+
+users:
+  - U
+
+constraints:
+  - C
+
+acceptance:
+  - A
+
+open_questions:
+  - Q
+
+non_goals:
+  - NG
+`
+    const spec = parseSpec(yaml)
+    expect(spec.goals).toEqual(['First goal line one continuation of first goal'])
+  })
+
+  test('"non goals" key (probe match without map entry) now resolves correctly', () => {
+    const yaml = `# SPEC
+
+goals:
+  - g
+
+users:
+  - u
+
+constraints:
+  - c
+
+acceptance:
+  - a
+
+open_questions:
+  - q
+
+non goals:
+  - ng
+`
+    const spec = parseSpec(yaml)
+    expect(spec.nonGoals).toEqual(['ng'])
+  })
+
+  test('BOM followed by canonical # SPEC + YAML sections parses correctly', () => {
+    // The adapter runs before BOM stripping. Verify a BOM at the start
+    // does not break either path: canonical heading detection or YAML key
+    // probe.
+    const BOM = '﻿'
+    const yaml = `${BOM}# SPEC
+
+goals:
+  - g
+
+users:
+  - u
+
+constraints:
+  - c
+
+acceptance:
+  - a
+
+open_questions:
+  - q
+
+non_goals:
+  - ng
+`
+    const spec = parseSpec(yaml)
+    expect(spec.title).toBe('SPEC')
+    expect(spec.goals).toEqual(['g'])
+  })
+})


### PR DESCRIPTION
## Summary

Same two-layer fix pattern as PR #6 (issue #5 HYPOTHESES YAML tolerance), applied proactively to the SPEC validator — the DEFINE-phase artifact and the highest-stakes parser-tolerance gap surfaced by the artifact-validator audit after the friend demo.

- Persona: `src/agents/defaults/ba.md` gets a "Canonical schemas (read before emitting)" block with explicit wrong / right examples + locked SPEC.md rules.
- Parser: `src/artifacts/spec.ts` gets `adaptYamlStyleSpec(raw)` — a narrow pre-parser that rewrites column-0 YAML keys (case-folded, with snake_case / camelCase / kebab-case aliases) plus indented `- bullet` lists or inline flow lists into canonical `## Heading\n\n- bullet` Markdown sections before strict parsing.
- Tests: 13 new regression cases (29 → 42 in `artifacts-spec.test.ts`).

## Why proactive

The audit triggered by issues #3 and #5 found three more validators in the same risk class — strict Markdown parsers vs. flexible LLM output. SPEC is the highest priority because it's the very first artifact in the SDLC; any drift here crashes the run before PLAN, exactly the "demo crashes immediately" failure mode that hurts first impressions. See issue #7 body for the full risk analysis.

The DEFINE-phase YAML drift has not been observed yet, but:
1. The BA persona's prompt had the same pre-#5 vagueness ("produce the complete SPEC.md draft in the canonical format" with no concrete example) that bit the Scientist persona.
2. The two-layer pattern from PR #6 is established, reviewable, and proven.
3. Better to ship the protection before the next demo than after.

## Test plan

- [x] 29 existing SPEC tests still pass
- [x] 13 new YAML-tolerance tests pass
- [x] Full offline suite: 2181 pass / 0 fail / 1 skip (gated live xAI)
- [x] `bun run typecheck` clean
- [x] No regressions in any of the 153 test files

Closes #7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SPEC documents now accept YAML-style formatting and automatically convert to canonical Markdown format.
  * Enhanced validation ensures SPEC documents follow a standardized structure with required sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->