### PR TITLE
fix(artifacts): tolerate YAML-style PLAN + SOURCE_CHECK section drift (#8, #9)

### DIFF
--- a/src/agents/defaults/lead.md
+++ b/src/agents/defaults/lead.md
@@ -87,3 +87,159 @@ Tasks that have no load-bearing claims write `- Hypotheses: none`.
 ## Output protocol
 
 Emit `<plan-ready/>` on its own line, then the canonical `# PLAN` document, then the canonical `# SOURCE_CHECK` document. The orchestrator splits on the H1 of SOURCE_CHECK and validates each block strictly. Validation failure produces a draft + `NEEDS_INTERVENTION`; do not retry by re-emitting — fix the specific schema violation the orchestrator surfaces.
+
+## Canonical schemas (read before emitting)
+
+Both `PLAN.md` and `SOURCE_CHECK.md` are **plain Markdown with `## ` H2 sections, dash bullets, and `### ` H3 blocks where called for**. They are NOT YAML. Do not emit top-level YAML keys (`tasks:`, `goals:`, `spec_sources:`) with indented list values, and do not emit `- id: T-NNN` / `- id: SC-NNN` block-style entries with indented `files:` / `validation:` / `quote:` continuations — the parsers reject both forms.
+
+### PLAN.md schema
+
+Wrong (YAML-style — parser rejects):
+
+```
+# PLAN
+
+goals:
+  - ship the scoring API.
+
+tasks:
+- id: T-001
+  title: implement scoring
+  files: [src/scoring.ts]
+  validation: bun test scoring
+  risk: none
+  hypotheses: [H-001]
+  sources: [SC-SPEC-001]
+
+sources:
+  - SC-SPEC-001
+
+out_of_scope:
+  - performance work.
+
+open_questions:
+  - none.
+```
+
+Right (Markdown sections + H3 task blocks — parser accepts):
+
+```
+# PLAN
+
+## Goals
+
+- Ship the scoring API.
+
+## Tasks
+
+### T-001: implement scoring
+
+- Files: src/scoring.ts (added)
+- Validation: bun test scoring
+- Risk: none
+- Hypotheses: H-001
+- Sources: SC-SPEC-001
+
+## Sources
+
+- SC-SPEC-001
+
+## Out of scope
+
+- Performance work.
+
+## Open questions
+
+- None known at plan time.
+```
+
+Required PLAN.md rules:
+
+- H1 form: `# PLAN`.
+- Five required H2 sections in this canonical order: `## Goals`, `## Tasks`, `## Sources`, `## Out of scope`, `## Open questions`.
+- Inside `## Tasks`, H3 task blocks: `### T-NNN: <title>` where `T-NNN` is zero-padded three or more digits (`T-001`, `T-042`).
+- Each task block requires five bullets in canonical order: `Files`, `Validation`, `Risk`, `Hypotheses`, `Sources`.
+- `Files:` is comma-separated, each `<path>` or `<path> (modified|added|deleted)`. Default change kind is `modified`.
+- `Validation:` is a single shell command on one line.
+- `Hypotheses:` is comma-separated `H-NNN` ids, or the literal `none`.
+- `Sources:` is comma-separated source ids drawn from `SOURCE_CHECK.md`.
+- All non-Tasks H2 sections are bullets-only. No paragraphs, no sub-headings, no code fences.
+- Empty open-questions sentinel: `- None known at plan time.`
+
+### SOURCE_CHECK.md schema
+
+Wrong (YAML-style — parser rejects):
+
+```
+# SOURCE_CHECK
+
+spec_sources:
+- id: SC-SPEC-001
+  title: AC for scoring API
+  spec: SPEC.md AC-1
+  quote: "Given a surname, the app produces 5 names."
+
+reference_sources:
+- id: SC-REF-NONE-001
+  title: no reference found
+  searched: glob src/**/scoring.ts (no files)
+  why_explicit: greenfield repo.
+
+docs_sources:
+- id: SC-DOC-001
+  title: bun test docs
+  library: bun
+  url: https://bun.sh/docs/test
+  section: pattern matching
+  why: bun-native test harness.
+
+coverage:
+  - T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001
+```
+
+Right (Markdown sections + H3 source blocks — parser accepts):
+
+```
+# SOURCE_CHECK
+
+## Spec sources
+
+### SC-SPEC-001: AC for scoring API
+
+- Spec: SPEC.md AC-1
+- Quote: "Given a surname, the app produces 5 names."
+
+## Reference sources
+
+### SC-REF-NONE-001: no reference found
+
+- Searched: glob src/**/scoring.ts
+- Result: no matching files (auto-extracted from Searched)
+- Why explicit: greenfield repo with no prior scoring module.
+
+## Docs sources
+
+### SC-DOC-001: bun test docs
+
+- Library: bun
+- URL: https://bun.sh/docs/test
+- Section: pattern matching
+- Why: bun-native test harness.
+
+## Coverage
+
+- T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001
+```
+
+Required SOURCE_CHECK.md rules:
+
+- H1 form: `# SOURCE_CHECK`.
+- Four required H2 sections: `## Spec sources`, `## Reference sources`, `## Docs sources`, `## Coverage`. Optional fifth: `## Open questions`.
+- Inside the three source sections, H3 source blocks: `### SC-<KIND>-NNN: <title>` where `<KIND>` is `SPEC`, `REF`, `REF-NONE`, `DOC`, or `DOC-NONE` and NNN is zero-padded three or more digits.
+- SPEC sources require `Spec:` and `Quote:` bullets.
+- REF sources require `Path:`, `Lines:`, and `Why:` bullets.
+- REF-NONE sources require `Searched:`, `Result:`, and `Why explicit:` bullets. The Result bullet is required even when empty — do not merge it into Searched.
+- DOC sources require `Library:`, `URL:`, `Section:`, and `Why:` bullets.
+- DOC-NONE sources require a `Why explicit:` bullet only.
+- Coverage: bullets of the form `- T-NNN -> SC-...,SC-...` mapping every task to the source ids it cites.
+- Every source id in Coverage must exist as an H3 block above; every `T-NNN` in PLAN.md must appear in Coverage.

--- a/src/agents/defaults/lead.md
+++ b/src/agents/defaults/lead.md
@@ -90,7 +90,7 @@ Emit `<plan-ready/>` on its own line, then the canonical `# PLAN` document, then
 
 ## Canonical schemas (read before emitting)
 
-Both `PLAN.md` and `SOURCE_CHECK.md` are **plain Markdown with `## ` H2 sections, dash bullets, and `### ` H3 blocks where called for**. They are NOT YAML. Do not emit top-level YAML keys (`tasks:`, `goals:`, `spec_sources:`) with indented list values, and do not emit `- id: T-NNN` / `- id: SC-NNN` block-style entries with indented `files:` / `validation:` / `quote:` continuations — the parsers reject both forms.
+Both `PLAN.md` and `SOURCE_CHECK.md` are **plain Markdown with `## ` H2 sections, dash bullets, and `### ` H3 blocks where called for**. The canonical contract is Markdown — emit Markdown, not YAML. The parsers include a narrow YAML-tolerance fallback for accidental section-level drift, but you must produce canonical Markdown by default. Nested `- id: T-NNN` / `- id: SC-NNN` block-style entries are rejected outright by the strict parser.
 
 ### PLAN.md schema
 

--- a/src/agents/defaults/lead.md
+++ b/src/agents/defaults/lead.md
@@ -94,7 +94,7 @@ Both `PLAN.md` and `SOURCE_CHECK.md` are **plain Markdown with `## ` H2 sections
 
 ### PLAN.md schema
 
-Wrong (YAML-style — parser rejects):
+Wrong (YAML-style — emit canonical Markdown instead; section-level keys hit the narrow tolerance fallback, and the nested `- id: ...` block form is rejected outright):
 
 ```
 # PLAN
@@ -121,7 +121,7 @@ open_questions:
   - none.
 ```
 
-Right (Markdown sections + H3 task blocks — parser accepts):
+Right (Markdown sections + H3 task blocks — canonical contract):
 
 ```
 # PLAN
@@ -168,7 +168,7 @@ Required PLAN.md rules:
 
 ### SOURCE_CHECK.md schema
 
-Wrong (YAML-style — parser rejects):
+Wrong (YAML-style — emit canonical Markdown instead; section-level keys hit the narrow tolerance fallback, and the nested `- id: ...` block form is rejected outright):
 
 ```
 # SOURCE_CHECK
@@ -197,7 +197,7 @@ coverage:
   - T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001
 ```
 
-Right (Markdown sections + H3 source blocks — parser accepts):
+Right (Markdown sections + H3 source blocks — canonical contract):
 
 ```
 # SOURCE_CHECK

--- a/src/artifacts/plan.ts
+++ b/src/artifacts/plan.ts
@@ -131,7 +131,11 @@ const YAML_PLAN_KEY_MAP: Readonly<Record<string, string>> = Object.freeze({
   'open-questions': 'Open questions',
 })
 
-const YAML_PLAN_KEY_PROBE = /^(?:goals|tasks|sources|out[ _-]?of[ _-]?scope|open[ _-]?questions):\s*(?:\[.*\])?\s*$/im
+// Probe enumerates the canonical alias forms exactly so that every shape
+// the probe accepts is also a key in YAML_PLAN_KEY_MAP. Mixed-separator
+// forms like `out_of-scope:` are intentionally NOT matched (probe-vs-map
+// alignment closed Codex round-1 fix-soon on PR #11).
+const YAML_PLAN_KEY_PROBE = /^(?:goals|tasks|sources|outofscope|out of scope|out_of_scope|out-of-scope|openquestions|open questions|open_questions|open-questions):\s*(?:\[.*\])?\s*$/im
 
 const YAML_PLAN_KEY_LINE = /^([A-Za-z][A-Za-z _-]*?):\s*(.*)$/
 
@@ -141,9 +145,10 @@ function normalizePlanKey(raw: string): string | null {
 }
 
 // Quote-aware top-level comma split — preserves quoted scalars containing
-// commas as single items. Required to honour the "rewrite shape, not
-// semantics" boundary (Codex review block-push finding on PR #10's
-// adapter; the same code shape was copied here).
+// commas as single items, including escaped quotes inside them. Required
+// to honour the "rewrite shape, not semantics" boundary (Codex review
+// block-push findings, rounds 1 and 2, on PR #10; same code shape copied
+// here).
 function splitTopLevelCommasPlan(s: string): string[] {
   const out: string[] = []
   let current = ''
@@ -151,6 +156,11 @@ function splitTopLevelCommasPlan(s: string): string[] {
   let inDouble = false
   for (let i = 0; i < s.length; i++) {
     const ch = s[i]!
+    if (ch === '\\' && i + 1 < s.length) {
+      current += ch + s[i + 1]
+      i++
+      continue
+    }
     if (ch === '"' && !inSingle) {
       inDouble = !inDouble
       current += ch
@@ -227,10 +237,13 @@ export function adaptYamlStylePlan(raw: string): string {
       i++
       continue
     }
+    const keyLineIdx = i
     const inlineValue = keyMatch[2]!.trim()
     const bullets: string[] = []
     if (inlineValue.length > 0) bullets.push(...parsePlanInlineList(inlineValue))
     i++
+    let firstBulletIndent = -1
+    let abortRewrite = false
     while (i < lines.length) {
       const cont = lines[i]!
       if (cont.length === 0) {
@@ -242,25 +255,45 @@ export function adaptYamlStylePlan(raw: string): string {
         continue
       }
       if (!/^[ \t]/.test(cont)) break
+      // Reject nested YAML key (indented `key:` with no leading `-`) and
+      // deeper-indent bullets — both indicate nested structure that the
+      // section-level adapter cannot safely rewrite (Codex round-2
+      // block-push finding on PR #10; same code shape copied here).
+      if (/^[ \t]+[A-Za-z][A-Za-z0-9_-]*\s*:\s*/.test(cont) && !/^[ \t]+-\s/.test(cont)) {
+        abortRewrite = true
+        break
+      }
       const indented = cont.match(/^[ \t]+-\s*(.*)$/)
-      if (indented === null) {
-        // Folded YAML continuation — append to the previous bullet so the
-        // author's content is preserved (Codex review block-push finding
-        // on PR #10's adapter; the same code shape was copied here).
-        const trimmedCont = cont.trim()
-        if (trimmedCont.length > 0) {
-          if (bullets.length > 0) {
-            bullets[bullets.length - 1] = `${bullets[bullets.length - 1]} ${trimmedCont}`
-          } else {
-            bullets.push(trimmedCont)
-          }
+      if (indented !== null) {
+        const bulletIndent = cont.search(/[^ \t]/)
+        if (firstBulletIndent === -1) {
+          firstBulletIndent = bulletIndent
+        } else if (bulletIndent > firstBulletIndent) {
+          abortRewrite = true
+          break
+        } else if (bulletIndent < firstBulletIndent) {
+          break
         }
+        const bullet = indented[1]!.trim()
+        if (bullet.length > 0) bullets.push(bullet)
         i++
         continue
       }
-      const bullet = indented[1]!.trim()
-      if (bullet.length > 0) bullets.push(bullet)
+      // Folded YAML continuation — append to the previous bullet so the
+      // author's content is preserved instead of silently dropped.
+      const trimmedCont = cont.trim()
+      if (trimmedCont.length > 0) {
+        if (bullets.length > 0) {
+          bullets[bullets.length - 1] = `${bullets[bullets.length - 1]} ${trimmedCont}`
+        } else {
+          bullets.push(trimmedCont)
+        }
+      }
       i++
+    }
+    if (abortRewrite) {
+      for (let j = keyLineIdx; j < i; j++) out.push(lines[j]!)
+      continue
     }
     out.push(`## ${heading}`)
     out.push('')

--- a/src/artifacts/plan.ts
+++ b/src/artifacts/plan.ts
@@ -140,13 +140,44 @@ function normalizePlanKey(raw: string): string | null {
   return YAML_PLAN_KEY_MAP[folded] ?? null
 }
 
+// Quote-aware top-level comma split — preserves quoted scalars containing
+// commas as single items. Required to honour the "rewrite shape, not
+// semantics" boundary (Codex review block-push finding on PR #10's
+// adapter; the same code shape was copied here).
+function splitTopLevelCommasPlan(s: string): string[] {
+  const out: string[] = []
+  let current = ''
+  let inSingle = false
+  let inDouble = false
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]!
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble
+      current += ch
+      continue
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle
+      current += ch
+      continue
+    }
+    if (ch === ',' && !inSingle && !inDouble) {
+      out.push(current)
+      current = ''
+      continue
+    }
+    current += ch
+  }
+  if (current.length > 0) out.push(current)
+  return out
+}
+
 function parsePlanInlineList(value: string): string[] {
   const trimmed = value.trim()
   if (trimmed.length === 0) return []
   const flow = trimmed.match(/^\[(.*)\]$/)
   const inner = flow !== null ? flow[1]! : trimmed
-  return inner
-    .split(',')
+  return splitTopLevelCommasPlan(inner)
     .map((s) => s.trim().replace(/^["']|["']$/g, ''))
     .filter((s) => s.length > 0)
 }
@@ -213,6 +244,17 @@ export function adaptYamlStylePlan(raw: string): string {
       if (!/^[ \t]/.test(cont)) break
       const indented = cont.match(/^[ \t]+-\s*(.*)$/)
       if (indented === null) {
+        // Folded YAML continuation — append to the previous bullet so the
+        // author's content is preserved (Codex review block-push finding
+        // on PR #10's adapter; the same code shape was copied here).
+        const trimmedCont = cont.trim()
+        if (trimmedCont.length > 0) {
+          if (bullets.length > 0) {
+            bullets[bullets.length - 1] = `${bullets[bullets.length - 1]} ${trimmedCont}`
+          } else {
+            bullets.push(trimmedCont)
+          }
+        }
         i++
         continue
       }

--- a/src/artifacts/plan.ts
+++ b/src/artifacts/plan.ts
@@ -97,6 +97,137 @@ export interface PlanArtifact {
   readonly openQuestions: readonly string[]
 }
 
+// --- YAML-style tolerance (issue #9) -------------------------------
+
+// LLMs occasionally emit PLAN.md as YAML at the section level — top-level
+// `goals:` / `sources:` / `out_of_scope:` / `open_questions:` keys with
+// indented `- bullet` lists, instead of canonical `## Heading\n\n- bullet`
+// Markdown sections. Tolerance scope: GitHub issue #9 — same drift class as
+// #5 (HYPOTHESES) and #7 (SPEC).
+//
+// Discipline boundary: this adapter handles SECTION-LEVEL drift only. Nested
+// `## Tasks` body H3 blocks (`### T-NNN:`) are NOT rewritten — the persona
+// prompt explicitly forbids nested `- id: T-NNN` YAML form (defense layer 1),
+// and the strict parser still owns task-block validation. If nested-task
+// YAML drift ever surfaces in practice, it gets its own follow-up issue.
+//
+// The adapter fires ONLY on column-0 lines that match a recognised PLAN
+// section key (case-insensitive, with snake_case / camelCase / kebab-case
+// aliases). Canonical `## ` headings, the `# PLAN` H1, the `## Tasks`
+// section body (preserved verbatim once we enter it), and unknown keys all
+// pass through. Mixed-format input is supported.
+
+const YAML_PLAN_KEY_MAP: Readonly<Record<string, string>> = Object.freeze({
+  goals: 'Goals',
+  tasks: 'Tasks',
+  sources: 'Sources',
+  'out of scope': 'Out of scope',
+  out_of_scope: 'Out of scope',
+  outofscope: 'Out of scope',
+  'out-of-scope': 'Out of scope',
+  'open questions': 'Open questions',
+  open_questions: 'Open questions',
+  openquestions: 'Open questions',
+  'open-questions': 'Open questions',
+})
+
+const YAML_PLAN_KEY_PROBE = /^(?:goals|tasks|sources|out[ _-]?of[ _-]?scope|open[ _-]?questions):\s*(?:\[.*\])?\s*$/im
+
+const YAML_PLAN_KEY_LINE = /^([A-Za-z][A-Za-z _-]*?):\s*(.*)$/
+
+function normalizePlanKey(raw: string): string | null {
+  const folded = raw.trim().toLowerCase()
+  return YAML_PLAN_KEY_MAP[folded] ?? null
+}
+
+function parsePlanInlineList(value: string): string[] {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return []
+  const flow = trimmed.match(/^\[(.*)\]$/)
+  const inner = flow !== null ? flow[1]! : trimmed
+  return inner
+    .split(',')
+    .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+    .filter((s) => s.length > 0)
+}
+
+/**
+ * Pre-parse adapter: rewrite SECTION-LEVEL YAML-style PLAN blocks (top-level
+ * `goals:` / `sources:` / etc. keys with indented `- bullet` list values or
+ * inline flow lists) into canonical `## Heading\n\n- bullet` Markdown
+ * sections. Returns the input unchanged if no YAML markers are present.
+ *
+ * Issue #9 tolerance, section level only. Mixed-format input is supported —
+ * canonical `## ` sections pass through verbatim; only YAML key/list pairs
+ * are rewritten. Nested `## Tasks` body H3 blocks (`### T-NNN:`) are NOT
+ * rewritten — that drift class would need its own follow-up.
+ */
+export function adaptYamlStylePlan(raw: string): string {
+  if (!YAML_PLAN_KEY_PROBE.test(raw)) return raw
+  const lines = raw.split(/\r?\n/)
+  const out: string[] = []
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]!
+    if (/^[ \t]/.test(line) || line.length === 0 || line.startsWith('#')) {
+      out.push(line)
+      i++
+      continue
+    }
+    const keyMatch = line.match(YAML_PLAN_KEY_LINE)
+    if (keyMatch === null) {
+      out.push(line)
+      i++
+      continue
+    }
+    const heading = normalizePlanKey(keyMatch[1]!)
+    if (heading === null) {
+      out.push(line)
+      i++
+      continue
+    }
+    if (heading === 'Tasks') {
+      // Tasks section body needs nested H3 blocks; the YAML form (`- id:`)
+      // is intentionally NOT rewritten. Emit the canonical heading and let
+      // the strict parser validate the body — if the persona drifted to
+      // YAML inside Tasks, the strict parser surfaces it.
+      out.push(`## ${heading}`)
+      out.push('')
+      i++
+      continue
+    }
+    const inlineValue = keyMatch[2]!.trim()
+    const bullets: string[] = []
+    if (inlineValue.length > 0) bullets.push(...parsePlanInlineList(inlineValue))
+    i++
+    while (i < lines.length) {
+      const cont = lines[i]!
+      if (cont.length === 0) {
+        let j = i + 1
+        while (j < lines.length && lines[j]!.length === 0) j++
+        if (j >= lines.length) break
+        if (!/^[ \t]+/.test(lines[j]!)) break
+        i++
+        continue
+      }
+      if (!/^[ \t]/.test(cont)) break
+      const indented = cont.match(/^[ \t]+-\s*(.*)$/)
+      if (indented === null) {
+        i++
+        continue
+      }
+      const bullet = indented[1]!.trim()
+      if (bullet.length > 0) bullets.push(bullet)
+      i++
+    }
+    out.push(`## ${heading}`)
+    out.push('')
+    for (const b of bullets) out.push(`- ${b}`)
+    out.push('')
+  }
+  return out.join('\n')
+}
+
 // --- parser --------------------------------------------------------
 
 const BOM = '﻿'
@@ -130,7 +261,8 @@ type SectionBuf = BulletSection | TaskSection
  */
 export function parsePlan(raw: string, file = 'PLAN.md'): PlanArtifact {
   const issues: PlanLoadIssue[] = []
-  const text = raw.startsWith(BOM) ? raw.slice(BOM.length) : raw
+  const adapted = adaptYamlStylePlan(raw)
+  const text = adapted.startsWith(BOM) ? adapted.slice(BOM.length) : adapted
 
   if (text.trim().length === 0) {
     throw new PlanLoadError([

--- a/src/artifacts/source-check.ts
+++ b/src/artifacts/source-check.ts
@@ -172,9 +172,10 @@ function normalizeSourceCheckKey(raw: string): string | null {
 }
 
 // Quote-aware top-level comma split — preserves quoted scalars containing
-// commas as single items. Required to honour the "rewrite shape, not
-// semantics" boundary (Codex review block-push finding on PR #10's
-// adapter; the same code shape was copied here).
+// commas as single items, including escaped quotes inside them. Required
+// to honour the "rewrite shape, not semantics" boundary (Codex review
+// block-push findings, rounds 1 and 2, on PR #10; same code shape copied
+// here).
 function splitTopLevelCommasSourceCheck(s: string): string[] {
   const out: string[] = []
   let current = ''
@@ -182,6 +183,11 @@ function splitTopLevelCommasSourceCheck(s: string): string[] {
   let inDouble = false
   for (let i = 0; i < s.length; i++) {
     const ch = s[i]!
+    if (ch === '\\' && i + 1 < s.length) {
+      current += ch + s[i + 1]
+      i++
+      continue
+    }
     if (ch === '"' && !inSingle) {
       inDouble = !inDouble
       current += ch
@@ -264,10 +270,13 @@ export function adaptYamlStyleSourceCheck(raw: string): string {
       continue
     }
     // Coverage or Open questions — collect indented bullets.
+    const keyLineIdx = i
     const inlineValue = keyMatch[2]!.trim()
     const bullets: string[] = []
     if (inlineValue.length > 0) bullets.push(...parseSourceCheckInlineList(inlineValue))
     i++
+    let firstBulletIndent = -1
+    let abortRewrite = false
     while (i < lines.length) {
       const cont = lines[i]!
       if (cont.length === 0) {
@@ -279,25 +288,44 @@ export function adaptYamlStyleSourceCheck(raw: string): string {
         continue
       }
       if (!/^[ \t]/.test(cont)) break
+      // Reject nested YAML key (indented `key:` with no leading `-`) and
+      // deeper-indent bullets (Codex round-2 block-push finding on PR #10;
+      // same code shape copied here).
+      if (/^[ \t]+[A-Za-z][A-Za-z0-9_-]*\s*:\s*/.test(cont) && !/^[ \t]+-\s/.test(cont)) {
+        abortRewrite = true
+        break
+      }
       const indented = cont.match(/^[ \t]+-\s*(.*)$/)
-      if (indented === null) {
-        // Folded YAML continuation — append to the previous bullet so the
-        // author's content is preserved (Codex review block-push finding
-        // on PR #10's adapter; the same code shape was copied here).
-        const trimmedCont = cont.trim()
-        if (trimmedCont.length > 0) {
-          if (bullets.length > 0) {
-            bullets[bullets.length - 1] = `${bullets[bullets.length - 1]} ${trimmedCont}`
-          } else {
-            bullets.push(trimmedCont)
-          }
+      if (indented !== null) {
+        const bulletIndent = cont.search(/[^ \t]/)
+        if (firstBulletIndent === -1) {
+          firstBulletIndent = bulletIndent
+        } else if (bulletIndent > firstBulletIndent) {
+          abortRewrite = true
+          break
+        } else if (bulletIndent < firstBulletIndent) {
+          break
         }
+        const bullet = indented[1]!.trim()
+        if (bullet.length > 0) bullets.push(bullet)
         i++
         continue
       }
-      const bullet = indented[1]!.trim()
-      if (bullet.length > 0) bullets.push(bullet)
+      // Folded YAML continuation — append to the previous bullet so the
+      // author's content is preserved instead of silently dropped.
+      const trimmedCont = cont.trim()
+      if (trimmedCont.length > 0) {
+        if (bullets.length > 0) {
+          bullets[bullets.length - 1] = `${bullets[bullets.length - 1]} ${trimmedCont}`
+        } else {
+          bullets.push(trimmedCont)
+        }
+      }
       i++
+    }
+    if (abortRewrite) {
+      for (let j = keyLineIdx; j < i; j++) out.push(lines[j]!)
+      continue
     }
     out.push(`## ${heading}`)
     out.push('')

--- a/src/artifacts/source-check.ts
+++ b/src/artifacts/source-check.ts
@@ -111,6 +111,160 @@ export interface SourceCheckArtifact {
   readonly openQuestions: readonly string[]
 }
 
+// --- YAML-style tolerance (issue #8) -------------------------------
+
+// LLMs occasionally emit SOURCE_CHECK.md as YAML at the section level —
+// top-level `spec_sources:` / `reference_sources:` / `docs_sources:` /
+// `coverage:` / `open_questions:` keys with indented values, instead of the
+// canonical `## Heading` H2 sections. Tolerance scope: GitHub issue #8 —
+// extends the issue #3 REF-NONE Result synthesis (kept as
+// `synthesizeRefNoneResult` below) with section-level tolerance for all
+// five kinds.
+//
+// Discipline boundary: this adapter handles SECTION-LEVEL drift only.
+// Nested H3 source blocks (`### SC-NNN:`) are NOT rewritten — the persona
+// prompt explicitly forbids nested `- id: SC-NNN` YAML form (defense layer
+// 1), and the strict parser still owns block validation. If nested-source
+// YAML drift surfaces in practice, it gets its own follow-up issue.
+//
+// The adapter fires ONLY on column-0 lines that match a recognised
+// SOURCE_CHECK section key (case-insensitive, with snake_case / camelCase /
+// kebab-case aliases). Canonical `## ` headings, the `# SOURCE_CHECK` H1,
+// the three source sections' bodies (preserved verbatim once we enter
+// them), and unknown keys all pass through. Mixed-format input is
+// supported.
+
+const YAML_SC_KEY_MAP: Readonly<Record<string, string>> = Object.freeze({
+  'spec sources': 'Spec sources',
+  spec_sources: 'Spec sources',
+  specsources: 'Spec sources',
+  'spec-sources': 'Spec sources',
+  'reference sources': 'Reference sources',
+  reference_sources: 'Reference sources',
+  referencesources: 'Reference sources',
+  'reference-sources': 'Reference sources',
+  references: 'Reference sources',
+  'docs sources': 'Docs sources',
+  docs_sources: 'Docs sources',
+  docssources: 'Docs sources',
+  'docs-sources': 'Docs sources',
+  docs: 'Docs sources',
+  coverage: 'Coverage',
+  'open questions': 'Open questions',
+  open_questions: 'Open questions',
+  openquestions: 'Open questions',
+  'open-questions': 'Open questions',
+})
+
+const YAML_SC_KEY_PROBE = /^(?:spec[ _-]?sources|reference[ _-]?sources|references|docs[ _-]?sources|docs|coverage|open[ _-]?questions):\s*(?:\[.*\])?\s*$/im
+
+const YAML_SC_KEY_LINE = /^([A-Za-z][A-Za-z _-]*?):\s*(.*)$/
+
+// The three source sections preserve their body verbatim — we emit the
+// canonical heading and let the strict parser validate `### SC-NNN:` block
+// shape inside. Coverage and Open questions are bullet sections and get
+// the SPEC-style indented-bullet collection.
+const YAML_SC_BULLET_SECTIONS: ReadonlySet<string> = new Set(['Coverage', 'Open questions'])
+
+function normalizeSourceCheckKey(raw: string): string | null {
+  const folded = raw.trim().toLowerCase()
+  return YAML_SC_KEY_MAP[folded] ?? null
+}
+
+function parseSourceCheckInlineList(value: string): string[] {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) return []
+  const flow = trimmed.match(/^\[(.*)\]$/)
+  const inner = flow !== null ? flow[1]! : trimmed
+  return inner
+    .split(',')
+    .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+    .filter((s) => s.length > 0)
+}
+
+/**
+ * Pre-parse adapter: rewrite SECTION-LEVEL YAML-style SOURCE_CHECK blocks
+ * (top-level `spec_sources:` / `coverage:` / etc. keys) into canonical
+ * `## Heading` Markdown sections. Returns the input unchanged if no YAML
+ * markers are present.
+ *
+ * Issue #8 tolerance, section level only. Mixed-format input is supported —
+ * canonical `## ` sections pass through verbatim; only YAML key/list pairs
+ * are rewritten. Nested `### SC-NNN:` H3 source blocks are NOT rewritten —
+ * that drift class would need its own follow-up.
+ *
+ * Coverage and Open questions sections collect their indented bullets
+ * (mirroring the SPEC adapter). The three source-block sections are emitted
+ * with the canonical heading only; their body content is preserved verbatim
+ * and the strict parser validates block shape.
+ */
+export function adaptYamlStyleSourceCheck(raw: string): string {
+  if (!YAML_SC_KEY_PROBE.test(raw)) return raw
+  const lines = raw.split(/\r?\n/)
+  const out: string[] = []
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]!
+    if (/^[ \t]/.test(line) || line.length === 0 || line.startsWith('#')) {
+      out.push(line)
+      i++
+      continue
+    }
+    const keyMatch = line.match(YAML_SC_KEY_LINE)
+    if (keyMatch === null) {
+      out.push(line)
+      i++
+      continue
+    }
+    const heading = normalizeSourceCheckKey(keyMatch[1]!)
+    if (heading === null) {
+      out.push(line)
+      i++
+      continue
+    }
+    if (!YAML_SC_BULLET_SECTIONS.has(heading)) {
+      // Spec/Reference/Docs source section — emit the canonical heading
+      // and let the body fall through to the strict parser. If the body
+      // uses YAML-style `- id: SC-NNN`, the strict parser correctly
+      // rejects it.
+      out.push(`## ${heading}`)
+      out.push('')
+      i++
+      continue
+    }
+    // Coverage or Open questions — collect indented bullets.
+    const inlineValue = keyMatch[2]!.trim()
+    const bullets: string[] = []
+    if (inlineValue.length > 0) bullets.push(...parseSourceCheckInlineList(inlineValue))
+    i++
+    while (i < lines.length) {
+      const cont = lines[i]!
+      if (cont.length === 0) {
+        let j = i + 1
+        while (j < lines.length && lines[j]!.length === 0) j++
+        if (j >= lines.length) break
+        if (!/^[ \t]+/.test(lines[j]!)) break
+        i++
+        continue
+      }
+      if (!/^[ \t]/.test(cont)) break
+      const indented = cont.match(/^[ \t]+-\s*(.*)$/)
+      if (indented === null) {
+        i++
+        continue
+      }
+      const bullet = indented[1]!.trim()
+      if (bullet.length > 0) bullets.push(bullet)
+      i++
+    }
+    out.push(`## ${heading}`)
+    out.push('')
+    for (const b of bullets) out.push(`- ${b}`)
+    out.push('')
+  }
+  return out.join('\n')
+}
+
 // --- parser --------------------------------------------------------
 
 const BOM = '﻿'
@@ -147,7 +301,8 @@ const REQUIRED_FIELDS_PER_KIND: Readonly<Record<SourceKind, readonly string[]>> 
 
 export function parseSourceCheck(raw: string, file = 'SOURCE_CHECK.md'): SourceCheckArtifact {
   const issues: SourceCheckLoadIssue[] = []
-  const text = raw.startsWith(BOM) ? raw.slice(BOM.length) : raw
+  const adapted = adaptYamlStyleSourceCheck(raw)
+  const text = adapted.startsWith(BOM) ? adapted.slice(BOM.length) : adapted
 
   if (text.trim().length === 0) {
     throw new SourceCheckLoadError([

--- a/src/artifacts/source-check.ts
+++ b/src/artifacts/source-check.ts
@@ -171,13 +171,44 @@ function normalizeSourceCheckKey(raw: string): string | null {
   return YAML_SC_KEY_MAP[folded] ?? null
 }
 
+// Quote-aware top-level comma split — preserves quoted scalars containing
+// commas as single items. Required to honour the "rewrite shape, not
+// semantics" boundary (Codex review block-push finding on PR #10's
+// adapter; the same code shape was copied here).
+function splitTopLevelCommasSourceCheck(s: string): string[] {
+  const out: string[] = []
+  let current = ''
+  let inSingle = false
+  let inDouble = false
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i]!
+    if (ch === '"' && !inSingle) {
+      inDouble = !inDouble
+      current += ch
+      continue
+    }
+    if (ch === "'" && !inDouble) {
+      inSingle = !inSingle
+      current += ch
+      continue
+    }
+    if (ch === ',' && !inSingle && !inDouble) {
+      out.push(current)
+      current = ''
+      continue
+    }
+    current += ch
+  }
+  if (current.length > 0) out.push(current)
+  return out
+}
+
 function parseSourceCheckInlineList(value: string): string[] {
   const trimmed = value.trim()
   if (trimmed.length === 0) return []
   const flow = trimmed.match(/^\[(.*)\]$/)
   const inner = flow !== null ? flow[1]! : trimmed
-  return inner
-    .split(',')
+  return splitTopLevelCommasSourceCheck(inner)
     .map((s) => s.trim().replace(/^["']|["']$/g, ''))
     .filter((s) => s.length > 0)
 }
@@ -250,6 +281,17 @@ export function adaptYamlStyleSourceCheck(raw: string): string {
       if (!/^[ \t]/.test(cont)) break
       const indented = cont.match(/^[ \t]+-\s*(.*)$/)
       if (indented === null) {
+        // Folded YAML continuation — append to the previous bullet so the
+        // author's content is preserved (Codex review block-push finding
+        // on PR #10's adapter; the same code shape was copied here).
+        const trimmedCont = cont.trim()
+        if (trimmedCont.length > 0) {
+          if (bullets.length > 0) {
+            bullets[bullets.length - 1] = `${bullets[bullets.length - 1]} ${trimmedCont}`
+          } else {
+            bullets.push(trimmedCont)
+          }
+        }
         i++
         continue
       }

--- a/tests/artifacts-plan.test.ts
+++ b/tests/artifacts-plan.test.ts
@@ -471,6 +471,69 @@ describe('parsePlan — issue #9 YAML tolerance', () => {
     expect(reparsed.tasks.length).toBe(plan.tasks.length)
   })
 
+  test('flow list with quoted comma keeps the scalar intact', () => {
+    // Quote-aware splitter regression — naive split would corrupt the goal.
+    const yaml = `# PLAN
+
+goals: ["first goal, with comma", "second goal"]
+
+## Tasks
+
+### T-001: t
+
+- Files: src/x.ts (modified)
+- Validation: bun test
+- Risk: none
+- Hypotheses: none
+- Sources: SC-SPEC-001
+
+sources:
+  - SC-SPEC-001
+
+## Out of scope
+
+- o
+
+## Open questions
+
+- q
+`
+    const plan = parsePlan(yaml)
+    expect(plan.goals).toEqual(['first goal, with comma', 'second goal'])
+  })
+
+  test('YAML continuation line is folded onto previous bullet, not dropped', () => {
+    const yaml = `# PLAN
+
+goals:
+  - First goal line one
+    continuation of first goal
+
+## Tasks
+
+### T-001: t
+
+- Files: src/x.ts (modified)
+- Validation: bun test
+- Risk: none
+- Hypotheses: none
+- Sources: SC-SPEC-001
+
+sources:
+  - SC-SPEC-001
+
+## Out of scope
+
+- o
+
+## Open questions
+
+- q
+`
+    const plan = parsePlan(yaml)
+    expect(plan.goals).toEqual(['First goal line one continuation of first goal'])
+  })
+
   test('still rejects nested YAML task blocks (defense layer 1: persona prompt)', () => {
     // Nested `- id: T-NNN` form inside Tasks is intentionally NOT rewritten
     // by the section-level adapter. The strict parser correctly rejects it.

--- a/tests/artifacts-plan.test.ts
+++ b/tests/artifacts-plan.test.ts
@@ -534,6 +534,73 @@ sources:
     expect(plan.goals).toEqual(['First goal line one continuation of first goal'])
   })
 
+  test('escaped double quote in flow scalar does not corrupt comma split', () => {
+    // PR #10 round-2 block-push regression mirrored to PLAN.
+    const yaml = `# PLAN
+
+goals: ["say \\"yes, now\\"", "second"]
+
+## Tasks
+
+### T-001: t
+
+- Files: src/x.ts (modified)
+- Validation: bun test
+- Risk: none
+- Hypotheses: none
+- Sources: SC-SPEC-001
+
+sources:
+  - SC-SPEC-001
+
+## Out of scope
+
+- o
+
+## Open questions
+
+- q
+`
+    const plan = parsePlan(yaml)
+    expect(plan.goals.length).toBe(2)
+    expect(plan.goals[0]).toContain('yes, now')
+    expect(plan.goals[1]).toBe('second')
+  })
+
+  test('nested YAML map under section key is rejected, not flattened', () => {
+    // PR #10 round-2 block-push regression mirrored to PLAN.
+    const yaml = `# PLAN
+
+goals:
+  - first
+    nested:
+      - sub1
+
+## Tasks
+
+### T-001: t
+
+- Files: src/x.ts (modified)
+- Validation: bun test
+- Risk: none
+- Hypotheses: none
+- Sources: SC-SPEC-001
+
+## Sources
+
+- SC-SPEC-001
+
+## Out of scope
+
+- o
+
+## Open questions
+
+- q
+`
+    expect(() => parsePlan(yaml)).toThrow()
+  })
+
   test('still rejects nested YAML task blocks (defense layer 1: persona prompt)', () => {
     // Nested `- id: T-NNN` form inside Tasks is intentionally NOT rewritten
     // by the section-level adapter. The strict parser correctly rejects it.

--- a/tests/artifacts-plan.test.ts
+++ b/tests/artifacts-plan.test.ts
@@ -4,6 +4,7 @@ import {
   serializePlan,
   hasMinimumContent,
   allocateTaskId,
+  adaptYamlStylePlan,
   PLAN_SECTION_KEYS,
   TASK_BULLET_KEYS,
   type PlanArtifact,
@@ -317,5 +318,190 @@ describe('PLAN_SECTION_KEYS', () => {
 describe('TASK_BULLET_KEYS', () => {
   test('canonical order matches contract', () => {
     expect(TASK_BULLET_KEYS).toEqual(['Files', 'Validation', 'Risk', 'Hypotheses', 'Sources'])
+  })
+})
+
+// --- issue #9: YAML-style PLAN tolerance (section level) -----------
+
+const YAML_PLAN_BULLET_SECTIONS = `# PLAN
+
+goals:
+  - Decompose the SPEC into atomic tasks.
+
+## Tasks
+
+### T-001: implement scoring
+
+- Files: src/scoring.ts (added)
+- Validation: bun test scoring
+- Risk: none
+- Hypotheses: H-001
+- Sources: SC-SPEC-001
+
+sources:
+  - SC-SPEC-001
+
+out_of_scope:
+  - performance optimisation.
+
+open_questions:
+  - none yet.
+`
+
+describe('adaptYamlStylePlan (issue #9)', () => {
+  test('returns input unchanged when no YAML markers are present', () => {
+    expect(adaptYamlStylePlan(VALID)).toBe(VALID)
+  })
+
+  test('returns input unchanged for empty / pre-title content', () => {
+    expect(adaptYamlStylePlan('')).toBe('')
+    expect(adaptYamlStylePlan('# PLAN\n')).toBe('# PLAN\n')
+  })
+
+  test('rewrites top-level YAML keys to canonical H2 headings', () => {
+    const out = adaptYamlStylePlan(YAML_PLAN_BULLET_SECTIONS)
+    expect(out).toContain('## Goals')
+    expect(out).toContain('## Sources')
+    expect(out).toContain('## Out of scope')
+    expect(out).toContain('## Open questions')
+  })
+
+  test('preserves canonical Tasks section verbatim', () => {
+    // The Tasks section uses H3 task blocks; the adapter must NOT touch it.
+    const out = adaptYamlStylePlan(YAML_PLAN_BULLET_SECTIONS)
+    expect(out).toContain('### T-001: implement scoring')
+    expect(out).toContain('- Files: src/scoring.ts (added)')
+    expect(out).toContain('- Validation: bun test scoring')
+  })
+
+  test('preserves bullet content from indented YAML lists', () => {
+    const out = adaptYamlStylePlan(YAML_PLAN_BULLET_SECTIONS)
+    expect(out).toContain('- Decompose the SPEC into atomic tasks.')
+    expect(out).toContain('- SC-SPEC-001')
+    expect(out).toContain('- performance optimisation.')
+  })
+
+  test('normalises snake_case / camelCase / kebab-case key aliases', () => {
+    const variants = `# PLAN
+
+Goals:
+  - g
+
+## Tasks
+
+### T-001: t
+
+- Files: src/x.ts (modified)
+- Validation: bun test
+- Risk: none
+- Hypotheses: none
+- Sources: SC-SPEC-001
+
+SOURCES:
+  - SC-SPEC-001
+
+outOfScope:
+  - o
+
+open-questions:
+  - q
+`
+    const out = adaptYamlStylePlan(variants)
+    expect(out).toContain('## Goals')
+    expect(out).toContain('## Sources')
+    expect(out).toContain('## Out of scope')
+    expect(out).toContain('## Open questions')
+  })
+
+  test('handles mixed format (canonical Goals, YAML Sources)', () => {
+    const mixed = `# PLAN
+
+## Goals
+
+- canonical goal stays.
+
+## Tasks
+
+### T-001: t
+
+- Files: src/x.ts (modified)
+- Validation: bun test
+- Risk: none
+- Hypotheses: none
+- Sources: SC-SPEC-001
+
+sources:
+  - SC-SPEC-001
+
+## Out of scope
+
+- o
+
+## Open questions
+
+- q
+`
+    const plan = parsePlan(mixed)
+    expect(plan.goals).toEqual(['canonical goal stays.'])
+    expect(plan.sources).toEqual(['SC-SPEC-001'])
+  })
+})
+
+describe('parsePlan — issue #9 YAML tolerance', () => {
+  test('parses YAML-style bullet sections end-to-end', () => {
+    const plan = parsePlan(YAML_PLAN_BULLET_SECTIONS)
+    expect(plan.title).toBe('PLAN')
+    expect(plan.goals.length).toBe(1)
+    expect(plan.tasks.length).toBe(1)
+    expect(plan.tasks[0]!.id).toBe('T-001')
+    expect(plan.sources).toEqual(['SC-SPEC-001'])
+    expect(plan.outOfScope).toEqual(['performance optimisation.'])
+  })
+
+  test('round-trips YAML-style sections through serialize → reparse to canonical', () => {
+    const plan = parsePlan(YAML_PLAN_BULLET_SECTIONS)
+    const serialized = serializePlan(plan)
+    expect(serialized).toContain('## Goals')
+    expect(serialized).toContain('## Sources')
+    expect(serialized).not.toMatch(/^goals:/m)
+    expect(serialized).not.toMatch(/^sources:/m)
+    const reparsed = parsePlan(serialized)
+    expect(reparsed.goals).toEqual(plan.goals)
+    expect(reparsed.sources).toEqual(plan.sources)
+    expect(reparsed.tasks.length).toBe(plan.tasks.length)
+  })
+
+  test('still rejects nested YAML task blocks (defense layer 1: persona prompt)', () => {
+    // Nested `- id: T-NNN` form inside Tasks is intentionally NOT rewritten
+    // by the section-level adapter. The strict parser correctly rejects it.
+    const nestedYaml = `# PLAN
+
+## Goals
+
+- g
+
+## Tasks
+
+- id: T-001
+  title: implement scoring
+  files: [src/scoring.ts]
+  validation: bun test scoring
+  risk: none
+  hypotheses: H-001
+  sources: SC-SPEC-001
+
+## Sources
+
+- SC-SPEC-001
+
+## Out of scope
+
+- o
+
+## Open questions
+
+- q
+`
+    expect(() => parsePlan(nestedYaml)).toThrow()
   })
 })

--- a/tests/artifacts-source-check.test.ts
+++ b/tests/artifacts-source-check.test.ts
@@ -3,6 +3,7 @@ import {
   parseSourceCheck,
   serializeSourceCheck,
   allocateSourceId,
+  adaptYamlStyleSourceCheck,
   SOURCE_CHECK_SECTION_KEYS,
 } from '../src/artifacts/source-check.ts'
 import { SourceCheckLoadError } from '../src/artifacts/errors.ts'
@@ -404,5 +405,213 @@ ${refNoneBody}
     if (ref.kind === 'REF-NONE') {
       expect(ref.result).toContain('auto-extracted')
     }
+  })
+})
+
+// --- issue #8: YAML-style SOURCE_CHECK tolerance (section level) ---
+
+const YAML_SC_BULLET_SECTIONS = `# SOURCE_CHECK
+
+## Spec sources
+
+### SC-SPEC-001: Acceptance criterion 1
+
+- Spec: SPEC.md ## Acceptance criteria, bullet 1
+- Quote: Given a surname, the app produces 5 candidate given names.
+
+## Reference sources
+
+### SC-REF-NONE-001: no reference found
+
+- Searched: glob src/**/scoring.ts
+- Result: no matching files (auto-extracted from Searched)
+- Why explicit: greenfield repo with no prior scoring module.
+
+## Docs sources
+
+### SC-DOC-001: bun test docs
+
+- Library: bun
+- URL: https://bun.sh/docs/test
+- Section: pattern matching
+- Why: bun-native test harness.
+
+coverage:
+  - T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001
+
+open_questions:
+  - none yet.
+`
+
+describe('adaptYamlStyleSourceCheck (issue #8)', () => {
+  test('returns input unchanged when no YAML markers are present', () => {
+    expect(adaptYamlStyleSourceCheck(VALID)).toBe(VALID)
+  })
+
+  test('returns input unchanged for empty / pre-title content', () => {
+    expect(adaptYamlStyleSourceCheck('')).toBe('')
+    expect(adaptYamlStyleSourceCheck('# SOURCE_CHECK\n')).toBe('# SOURCE_CHECK\n')
+  })
+
+  test('rewrites top-level YAML keys to canonical H2 headings (Coverage + Open questions)', () => {
+    const out = adaptYamlStyleSourceCheck(YAML_SC_BULLET_SECTIONS)
+    expect(out).toContain('## Coverage')
+    expect(out).toContain('## Open questions')
+  })
+
+  test('preserves canonical source sections verbatim', () => {
+    const out = adaptYamlStyleSourceCheck(YAML_SC_BULLET_SECTIONS)
+    expect(out).toContain('### SC-SPEC-001:')
+    expect(out).toContain('### SC-REF-NONE-001:')
+    expect(out).toContain('### SC-DOC-001:')
+    expect(out).toContain('- Spec: SPEC.md')
+    expect(out).toContain('- Library: bun')
+  })
+
+  test('preserves bullet content from indented Coverage YAML list', () => {
+    const out = adaptYamlStyleSourceCheck(YAML_SC_BULLET_SECTIONS)
+    expect(out).toContain('- T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001')
+  })
+
+  test('rewrites YAML source-section keys to canonical H2 (heading-only)', () => {
+    // When the persona uses YAML for the source SECTIONS too, the adapter
+    // emits the canonical heading so the strict parser can run. The body
+    // must already be canonical H3 blocks (the persona prompt forbids
+    // nested YAML); if it isn't, the strict parser will reject it.
+    const yamlSections = `# SOURCE_CHECK
+
+spec_sources:
+
+### SC-SPEC-001: AC 1
+
+- Spec: SPEC.md ## Acceptance criteria, bullet 1
+- Quote: Given a surname, the app produces 5 candidate given names.
+
+reference_sources:
+
+### SC-REF-NONE-001: no reference
+
+- Searched: glob src/**/scoring.ts
+- Result: no matching files (auto-extracted from Searched)
+- Why explicit: greenfield.
+
+docs_sources:
+
+### SC-DOC-001: bun test
+
+- Library: bun
+- URL: https://bun.sh/docs/test
+- Section: pattern matching
+- Why: bun harness.
+
+## Coverage
+
+- T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001
+`
+    const out = adaptYamlStyleSourceCheck(yamlSections)
+    expect(out).toContain('## Spec sources')
+    expect(out).toContain('## Reference sources')
+    expect(out).toContain('## Docs sources')
+  })
+
+  test('normalises snake_case / camelCase / kebab-case key aliases', () => {
+    // Use an input where the source sections already have headings + blocks,
+    // and only the bullet sections (Coverage + Open questions) drift to YAML
+    // with alias keys.
+    const variants = `# SOURCE_CHECK
+
+## Spec sources
+
+### SC-SPEC-001: t
+
+- Spec: SPEC.md AC-1
+- Quote: q
+
+## Reference sources
+
+### SC-REF-NONE-001: t
+
+- Searched: glob src/**/x.ts
+- Result: no matching files
+- Why explicit: greenfield.
+
+## Docs sources
+
+### SC-DOC-001: t
+
+- Library: bun
+- URL: https://bun.sh/docs/test
+- Section: s
+- Why: w
+
+COVERAGE:
+  - T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001
+
+openQuestions:
+  - q
+`
+    const out = adaptYamlStyleSourceCheck(variants)
+    expect(out).toContain('## Coverage')
+    expect(out).toContain('## Open questions')
+  })
+})
+
+describe('parseSourceCheck — issue #8 YAML tolerance', () => {
+  test('parses YAML-style Coverage + Open questions end-to-end', () => {
+    const sc = parseSourceCheck(YAML_SC_BULLET_SECTIONS)
+    expect(sc.title).toBe('SOURCE_CHECK')
+    expect(sc.specSources.length).toBe(1)
+    expect(sc.referenceSources.length).toBe(1)
+    expect(sc.docsSources.length).toBe(1)
+    expect(sc.coverage.length).toBe(1)
+    expect(sc.coverage[0]!.taskId).toBe('T-001')
+    expect(sc.openQuestions).toEqual(['none yet.'])
+  })
+
+  test('round-trips YAML-style sections through serialize → reparse to canonical', () => {
+    const sc = parseSourceCheck(YAML_SC_BULLET_SECTIONS)
+    const serialized = serializeSourceCheck(sc)
+    expect(serialized).toContain('## Coverage')
+    expect(serialized).not.toMatch(/^coverage:/m)
+    expect(serialized).not.toMatch(/^open_questions:/m)
+    const reparsed = parseSourceCheck(serialized)
+    expect(reparsed.coverage.length).toBe(sc.coverage.length)
+    expect(reparsed.openQuestions).toEqual(sc.openQuestions)
+  })
+
+  test('still rejects nested YAML source blocks (defense layer 1: persona prompt)', () => {
+    // Nested `- id: SC-NNN` form is intentionally NOT rewritten by the
+    // section-level adapter. The strict parser correctly rejects it.
+    const nestedYaml = `# SOURCE_CHECK
+
+## Spec sources
+
+- id: SC-SPEC-001
+  title: AC 1
+  spec: SPEC.md AC-1
+  quote: q
+
+## Reference sources
+
+### SC-REF-NONE-001: t
+
+- Searched: glob ** (no files)
+- Result: no matching files
+- Why explicit: greenfield.
+
+## Docs sources
+
+### SC-DOC-001: t
+
+- Library: bun
+- URL: https://bun.sh/docs/test
+- Section: s
+- Why: w
+
+## Coverage
+
+- T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001
+`
+    expect(() => parseSourceCheck(nestedYaml)).toThrow()
   })
 })

--- a/tests/artifacts-source-check.test.ts
+++ b/tests/artifacts-source-check.test.ts
@@ -579,6 +579,80 @@ describe('parseSourceCheck — issue #8 YAML tolerance', () => {
     expect(reparsed.openQuestions).toEqual(sc.openQuestions)
   })
 
+  test('flow list with quoted comma in Coverage keeps the scalar intact', () => {
+    // Quote-aware splitter regression on Coverage's flow list.
+    const yaml = `# SOURCE_CHECK
+
+## Spec sources
+
+### SC-SPEC-001: t
+
+- Spec: SPEC.md AC-1
+- Quote: "Given a surname, the app produces 5 names."
+
+## Reference sources
+
+### SC-REF-NONE-001: t
+
+- Searched: glob src/**/x.ts
+- Result: no matching files
+- Why explicit: greenfield.
+
+## Docs sources
+
+### SC-DOC-001: t
+
+- Library: bun
+- URL: https://bun.sh/docs/test
+- Section: s
+- Why: w
+
+coverage: ["T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001"]
+`
+    const sc = parseSourceCheck(yaml)
+    expect(sc.coverage.length).toBe(1)
+    expect(sc.coverage[0]!.taskId).toBe('T-001')
+  })
+
+  test('YAML continuation line in Open questions is folded, not dropped', () => {
+    const yaml = `# SOURCE_CHECK
+
+## Spec sources
+
+### SC-SPEC-001: t
+
+- Spec: SPEC.md AC-1
+- Quote: q
+
+## Reference sources
+
+### SC-REF-NONE-001: t
+
+- Searched: glob src/**/x.ts
+- Result: no matching files
+- Why explicit: greenfield.
+
+## Docs sources
+
+### SC-DOC-001: t
+
+- Library: bun
+- URL: https://bun.sh/docs/test
+- Section: s
+- Why: w
+
+## Coverage
+
+- T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001
+
+open_questions:
+  - First question line one
+    continuation of first question
+`
+    const sc = parseSourceCheck(yaml)
+    expect(sc.openQuestions).toEqual(['First question line one continuation of first question'])
+  })
+
   test('still rejects nested YAML source blocks (defense layer 1: persona prompt)', () => {
     // Nested `- id: SC-NNN` form is intentionally NOT rewritten by the
     // section-level adapter. The strict parser correctly rejects it.

--- a/tests/artifacts-source-check.test.ts
+++ b/tests/artifacts-source-check.test.ts
@@ -653,6 +653,78 @@ open_questions:
     expect(sc.openQuestions).toEqual(['First question line one continuation of first question'])
   })
 
+  test('escaped double quote in Coverage flow scalar does not corrupt split', () => {
+    // PR #10 round-2 block-push regression mirrored to SOURCE_CHECK.
+    const yaml = `# SOURCE_CHECK
+
+## Spec sources
+
+### SC-SPEC-001: t
+
+- Spec: SPEC.md AC-1
+- Quote: q
+
+## Reference sources
+
+### SC-REF-NONE-001: t
+
+- Searched: glob src/**/x.ts
+- Result: no matching files
+- Why explicit: greenfield.
+
+## Docs sources
+
+### SC-DOC-001: t
+
+- Library: bun
+- URL: https://bun.sh/docs/test
+- Section: s
+- Why: w
+
+coverage: ["T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001", "T-002 -> SC-SPEC-001"]
+`
+    const sc = parseSourceCheck(yaml)
+    expect(sc.coverage.length).toBe(2)
+    expect(sc.coverage[0]!.taskId).toBe('T-001')
+    expect(sc.coverage[1]!.taskId).toBe('T-002')
+  })
+
+  test('nested YAML map under Coverage key is rejected, not flattened', () => {
+    // PR #10 round-2 block-push regression mirrored to SOURCE_CHECK.
+    const yaml = `# SOURCE_CHECK
+
+## Spec sources
+
+### SC-SPEC-001: t
+
+- Spec: SPEC.md AC-1
+- Quote: q
+
+## Reference sources
+
+### SC-REF-NONE-001: t
+
+- Searched: glob src/**/x.ts
+- Result: no matching files
+- Why explicit: greenfield.
+
+## Docs sources
+
+### SC-DOC-001: t
+
+- Library: bun
+- URL: https://bun.sh/docs/test
+- Section: s
+- Why: w
+
+coverage:
+  - T-001 -> SC-SPEC-001, SC-REF-NONE-001, SC-DOC-001
+    nested:
+      - x
+`
+    expect(() => parseSourceCheck(yaml)).toThrow()
+  })
+
   test('still rejects nested YAML source blocks (defense layer 1: persona prompt)', () => {
     // Nested `- id: SC-NNN` form is intentionally NOT rewritten by the
     // section-level adapter. The strict parser correctly rejects it.


### PR DESCRIPTION
## Summary

Same two-layer fix pattern as PR #6 (issue #5 HYPOTHESES YAML tolerance) and PR #10 (issue #7 SPEC YAML tolerance), applied proactively to the two Lead-persona artifacts. PLAN.md and SOURCE_CHECK.md are both emitted by `src/agents/defaults/lead.md`, so this single PR covers both issues #8 and #9.

- Persona: `src/agents/defaults/lead.md` gets a "Canonical schemas (read before emitting)" section with explicit wrong / right examples for both PLAN.md and SOURCE_CHECK.md plus the locked rules (section names, H3 block forms, bullet keys, sentinel strings).
- Parsers: `src/artifacts/plan.ts` gets `adaptYamlStylePlan(raw)` and `src/artifacts/source-check.ts` gets `adaptYamlStyleSourceCheck(raw)`. Both pre-rewrite SECTION-LEVEL YAML keys (case-folded, with snake_case / camelCase / kebab-case aliases) into canonical `## Heading` Markdown sections.
- Tests: 20 new regression cases (13 PLAN + 7 SOURCE_CHECK).

## Why combined PR

Same precedent as PR #6, which combined HYPOTHESES.md and OPEN_QUESTIONS.md into a single PR because both share the Scientist persona (`scientist.md`). PLAN.md and SOURCE_CHECK.md both share the Lead persona (`lead.md`), so the canonical-schemas block lands in one place and the two parser adapters land alongside it. Avoiding a parallel-branch lead.md merge conflict was the practical motivation; matching #6's precedent was the principled one.

## Scope: section-level YAML drift only

The adapters handle **section-level** drift (`tasks:` / `goals:` / `coverage:` etc. as top-level YAML keys). They do NOT rewrite **nested H3 block YAML** (`- id: T-NNN` per-task or `- id: SC-NNN` per-source) — the persona prompt explicitly forbids that form (defense layer 1) and the strict parser correctly rejects it (defense layer 3). If nested-block YAML drift surfaces in the wild, it gets its own follow-up issue.

Section handling differences between the adapters:
- **PLAN**: the `## Tasks` body is preserved verbatim — H3 task blocks must be in canonical Markdown form. Other sections collect indented bullets like the SPEC adapter.
- **SOURCE_CHECK**: the three source sections (Spec / Reference / Docs) emit the canonical heading and let the body fall through to the strict parser. Coverage and Open questions collect indented bullets.

Issue #3's `synthesizeRefNoneResult` for REF-NONE is preserved unchanged — it operates on canonical Markdown after the YAML adapter runs.

## Why proactive

Same reasoning as PR #10 (issue #7). The audit triggered by issues #3 and #5 found both PLAN and SOURCE_CHECK in the same risk class — strict Markdown parsers vs. flexible LLM output, with the Lead persona's prompt carrying the same pre-#5 vagueness that bit the Scientist persona. Section-level YAML drift has not been observed in the wild yet; better to ship the protection before the next demo than after.

## Test plan

- [x] 69 existing PLAN + SOURCE_CHECK tests still pass
- [x] 20 new YAML-tolerance tests pass
- [x] Full offline suite: 2188 pass / 0 fail / 1 skip (gated live xAI)
- [x] `bun run typecheck` clean
- [x] No regressions in any of the 153 test files

Closes #8
Closes #9