### PR TITLE
Link CHANGELOG from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,10 @@ mkdir /tmp/code-oz-smoke && cd /tmp/code-oz-smoke
 - Setup, tests, commit conventions, PR expectations: [`CONTRIBUTING.md`](CONTRIBUTING.md)
 - Community standards: [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)
 
+## Changelog
+
+Release notes and version history are tracked in [`CHANGELOG.md`](CHANGELOG.md).
+
 ## Roadmap
 
 Public summary at [`docs/design/ROADMAP.md#now-next-later`](docs/design/ROADMAP.md#now-next-later). The detailed milestone inventory follows in the same file.


### PR DESCRIPTION
- add a short README Changelog section near the contributor/community links
- link the section to the repository's existing `CHANGELOG.md` using a relative path

Fixes #32.

## Verification

- `git diff --check -- README.md`
- `bun install --frozen-lockfile`
- `bun run typecheck`
- `bun run test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Changelog" section to the README directing users to release notes and version history.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omerakben/code-oz/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->