### PR TITLE
docs(branching): codify trunk-based Option A workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ The `templates/` collection in `~/Projects/agents/templates/` is the influence l
 ## Working in this repo
 
 1. **Run all commands from the repo root.** `bun install`, `bun test`, `bun run dev <command>`, `bun run build:binary`.
-2. **Branches:** `main` only on tagged releases. Feature branches: `feat/`, `fix/`, `refactor/`, `test/`, `docs/`. Conventional commit messages.
+2. **Branching is trunk-based (Option A, locked 2026-05-29).** `main` is the protected trunk and the only long-lived branch. Every change lands via a short-lived branch -> PR -> green CI -> **squash-merge** -> head branch auto-deletes (merge-commit and rebase-merge are disabled). Prefixes: `feat/`, `fix/`, `refactor/`, `test/`, `docs/`, `chore/`, with a kebab-case slug after the slash, optionally issue-scoped (`fix/123-worktree-reset`). One branch = one PR = one squashed conventional commit = one concern; branch from latest `main` (`git fetch origin && git switch -c feat/<slug> origin/main`), never from another topic branch; never push `worktree-*` scratch branches. Releases are annotated SemVer tags (`vX.Y.Z-alpha.N`) on a green `main`, cut behind a `chore/release-*` PR. `main` is protected for everyone including admins (required `bun test` checks, linear history, no force-push or deletion, PR-before-merge). Full contract: CONTRIBUTING.md § "Branching and merge workflow".
 3. **Tests must run offline.** Spine tests use `FakeProvider`. Live-provider tests are opt-in only and gated behind env flags.
 4. **No emojis in code or commit messages.** No "Co-Authored-By: Claude" footers unless asked.
 5. **Never push to GitHub without explicit user approval.** Local commits are fine.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,15 +78,21 @@ Common scopes: `readme`, `providers`, `gates`, `cli`, `demo`, `package`, the mil
 - **No squash-commit messages with raw model output.** Edit the message before committing.
 - **No secret material** (API keys, tokens, customer data, internal hostnames) anywhere in the diff or message.
 
-### Branch naming
+### Branching and merge workflow
 
-- `feat/<scope>-<topic>` for new features
-- `fix/<scope>-<topic>` for bug fixes
-- `refactor/<scope>-<topic>` for refactors
-- `docs/<scope>-<topic>` for docs-only changes
-- `test/<scope>-<topic>` for test-only additions
+The repo is **trunk-based** (locked 2026-05-29). `main` is the protected trunk; everything else is a short-lived branch.
 
-`main` is tag-only. Pushes to `main` happen at release time.
+- Branch from the latest `main`: `git fetch origin && git switch -c feat/<slug> origin/main`. Never branch from another topic branch.
+- Prefixes: `feat/`, `fix/`, `refactor/`, `test/`, `docs/`, `chore/`. After the slash, a short kebab-case slug, optionally issue-scoped: `fix/123-worktree-reset-on-restart`.
+- One branch = one PR = one concern. If a branch grows a second concern, cut a second branch.
+- Open the PR the same session and keep branches short-lived. On merge the branch **auto-deletes** — do not delete it by hand.
+- Never push `worktree-*` scratch branches; git worktrees stay local.
+
+**Merging.** PRs **squash-merge** into `main` (merge commits and rebase-merge are disabled), so one PR becomes exactly one conventional commit on `main`. The PR title is the squash commit subject, so it must be Conventional-Commit form.
+
+**`main` is protected.** Required status checks (`bun test on ubuntu-latest`, `bun test on macos-latest`), strict/up-to-date, linear history, no force-push, no deletion, PR-before-merge — enforced for everyone including admins. There are no direct pushes to `main`.
+
+**Releases.** Annotated SemVer tags (`vX.Y.Z-alpha.N`) on a green `main` commit, cut behind a `chore/release-*` PR (version bump + CHANGELOG) so the bump itself passes CI. One tag per release; tags are never moved.
 
 ## Pull request expectations
 
@@ -121,7 +127,7 @@ When adding a new provider adapter or modifying an existing one:
 - A maintainer triages within a few days. Triage adds labels and may ask for clarification.
 - Substantive PRs get a Codex review pass (see above). The review verdict is recorded in the PR conversation.
 - Block-push findings close in a follow-up commit on the PR branch before merge.
-- The merge strategy is squash-merge to `finalize/<release>` branches or rebase to feature branches. `main` only receives release tags.
+- The merge strategy is **squash-merge into `main`**; the head branch auto-deletes on merge. Release tags are cut on `main` behind a `chore/release-*` PR (see "Branching and merge workflow").
 
 ## Code of conduct
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Requirements:
 - **Node 18 or newer** for the npm wrapper smoke (`node --version`).
 - macOS arm64, macOS x64, Linux x64, or Linux arm64. Windows local development is not currently supported (the npm wrapper and binaries are Unix-only).
 
-The full offline test suite runs in under 30 seconds on a recent machine and should report `3395 pass / 0 fail / 2 skip` against `main`. The two skipped tests are the opt-in live-provider tests described below.
+The full offline test suite runs in under 30 seconds on a recent machine and should report `3750+ pass / 0 fail` against `main` (the pass count grows as suites are added; the 2 skipped tests are the opt-in live-provider tests described below).
 
 ## Test discipline
 


### PR DESCRIPTION
Codifies the trunk-based **Option A** branching strategy adopted 2026-05-29, so the docs match the GitHub repo settings now in force.

## What changed
- **`CLAUDE.md`** — "Working in this repo" rule 2 rewritten from the one-line "main only on tagged releases" into the full trunk-based contract: branch from latest `main`, `feat|fix|refactor|test|docs|chore/` prefixes with issue-scoped slugs, one-branch = one-PR = one-squashed-commit, squash-merge + auto-delete, protected `main`, releases as tags behind `chore/release-*` PRs.
- **`CONTRIBUTING.md`** — replaced the "Branch naming" subsection with a "Branching and merge workflow" section covering the same contract, and fixed the stale "squash-merge to `finalize/<release>` branches or rebase to feature branches / `main` only receives release tags" line (that pattern is retired) to "squash-merge into `main`; head branch auto-deletes."

## Why
On 2026-05-29 the repo settings were changed to match Option A: `deleteBranchOnMerge=on`, squash-only (merge-commit + rebase-merge disabled), and `main` branch protection (required `bun test` checks on both runners, strict/linear history, no force-push or deletion, PR-before-merge, `enforce_admins` on). The docs still described an older `finalize/<release>` + tag-only flow that no longer matches reality. This PR is the documentation half of that change.

Docs-only. `bun test ./tests` is green locally: **3789 pass / 0 fail / 2 skip**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified and tightened trunk-based workflow: protected main, short-lived PR branches, required branch-name prefixes and kebab-case slugs, and branch/PR creation rules.
  * Specified mandatory squash-merge into main, disabled merge-commit/rebase merges, and formalized release tagging and release-PR conventions.
  * Updated offline test-suite expectations (pass/skip counts) and PR auto-delete behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omerakben/code-oz/pull/44?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->