### PR TITLE
fix(plugins): drop redundant hooks key so the code-oz plugin loads

### DIFF
--- a/plugins/code-oz/.claude-plugin/plugin.json
+++ b/plugins/code-oz/.claude-plugin/plugin.json
@@ -12,6 +12,5 @@
     "./commands/code-oz-init.md",
     "./commands/code-oz-doctor.md",
     "./commands/code-oz-resume.md"
-  ],
-  "hooks": "./hooks/hooks.json"
+  ]
 }

--- a/tests/plugins/manifest-shape.test.ts
+++ b/tests/plugins/manifest-shape.test.ts
@@ -42,7 +42,11 @@ describe('plugins/code-oz manifest shape', () => {
     expect(plugin.name).toBe('code-oz')
     expect(typeof plugin.description).toBe('string')
     expect((plugin.description as string).length).toBeGreaterThan(0)
-    expect(plugin.hooks).toBe('./hooks/hooks.json')
+    // The standard hooks/hooks.json auto-loads. Declaring it in manifest.hooks
+    // makes Claude Code load it twice and the plugin fails to load entirely
+    // ("Duplicate hooks file detected"). manifest.hooks must reference only
+    // ADDITIONAL hook files, so the code-oz plugin must not set it.
+    expect(plugin.hooks).toBeUndefined()
     expect(Array.isArray(plugin.commands)).toBe(true)
     expect(plugin.commands).toEqual(EXPECTED_COMMANDS)
   })


### PR DESCRIPTION
## Why

Discovered by a real post-merge dogfood of #45: `claude plugin marketplace add omerakben/code-oz` + `plugin install code-oz@code-oz-marketplace` installs the plugin, but it **fails to load**:

> Hook load failed: Duplicate hooks file detected: `./hooks/hooks.json` ... The standard `hooks/hooks.json` is loaded automatically, so `manifest.hooks` should only reference additional hook files.

Claude Code auto-discovers `hooks/hooks.json` from the plugin root. The `code-oz` plugin also declared `"hooks": "./hooks/hooks.json"` in `plugin.json`, so it loaded twice and the whole plugin (commands + hook) failed to load. `claude plugin validate` and the offline suite passed because they asserted the broken value, not load behavior — only a real install surfaced it.

## What

- Remove the `hooks` key from `plugins/code-oz/.claude-plugin/plugin.json`. The SessionStart router still loads via the conventional path (confirmed against the plugin reference docs: hooks auto-load from `hooks/hooks.json`; manifest `hooks` is for *additional* files only).
- Flip the manifest test RED-first to assert the key is absent.

## Verification

- Real `marketplace add` + `plugin install` of both plugins now shows `code-oz` Status: **enabled** (was "failed to load"); `code-oz-discipline` unchanged.
- `claude plugin validate` passes; 3812 offline tests pass; typecheck clean.