### PR TITLE
fix(plugins): strip empty-string args in resolver so no-arg slash commands work

### DIFF
--- a/plugins/code-oz/scripts/resolve-code-oz.sh
+++ b/plugins/code-oz/scripts/resolve-code-oz.sh
@@ -69,6 +69,22 @@ case "${OS_NAME}" in
 esac
 
 # ---------------------------------------------------------------------------
+# Drop empty-string positional arguments before resolution. A plugin command
+# card renders `<subcommand> "$ARGUMENTS"`; with no user arguments Claude Code
+# substitutes an empty $ARGUMENTS, leaving a literal "" that the engine's
+# subcommand dispatcher (0.21.1+) rejects as an unknown subcommand. An empty
+# positional is never meaningful to code-oz, so the launcher strips it before
+# both the PATH-exec and npx branches. The array form preserves args that
+# contain spaces; ${a[@]+"${a[@]}"} is the bash-3.2 + `set -u`-safe way to
+# expand a possibly-empty array.
+# ---------------------------------------------------------------------------
+filtered_args=()
+for arg in "$@"; do
+  [ -n "${arg}" ] && filtered_args+=("${arg}")
+done
+set -- ${filtered_args[@]+"${filtered_args[@]}"}
+
+# ---------------------------------------------------------------------------
 # 2. code-oz found on PATH — exec directly, forwarding all args.
 # ---------------------------------------------------------------------------
 if command -v code-oz >/dev/null 2>&1; then

--- a/tests/plugins/bootstrap-resolver.test.ts
+++ b/tests/plugins/bootstrap-resolver.test.ts
@@ -122,6 +122,42 @@ describe('resolve-code-oz.sh — PATH binary present', () => {
     expect(result.stdout).toContain('--provider')
     expect(result.stdout).toContain('fake')
   })
+
+  test('strips an empty-string positional before exec (no-args plugin card artifact)', async () => {
+    // A plugin command card renders `<subcommand> "$ARGUMENTS"`. With no user
+    // arguments Claude Code substitutes an empty $ARGUMENTS, leaving a literal
+    // `doctor ""`. The empty positional must not reach the engine, whose 0.21.1
+    // subcommand dispatcher rejects '' as an unknown subcommand. The fake wraps
+    // each forwarded arg in brackets, so an empty arg would appear as `[]`.
+    const fakeDir = await makeFakeBinDir({
+      'code-oz': `#!/bin/sh\nprintf 'ARGS:'\nfor a in "$@"; do printf '[%s]' "$a"; done\nprintf '\\n'\n`,
+    })
+
+    const result = await runResolver({
+      path: `${fakeDir}:${SYSTEM_BIN}`,
+      args: ['doctor', ''],
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('[doctor]')
+    expect(result.stdout).not.toContain('[]')
+  })
+
+  test('preserves a non-empty positional that contains spaces', async () => {
+    // The empty-arg filter must not word-split or drop legitimate args.
+    const fakeDir = await makeFakeBinDir({
+      'code-oz': `#!/bin/sh\nprintf 'ARGS:'\nfor a in "$@"; do printf '[%s]' "$a"; done\nprintf '\\n'\n`,
+    })
+
+    const result = await runResolver({
+      path: `${fakeDir}:${SYSTEM_BIN}`,
+      args: ['run', 'fix the login bug'],
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('[run]')
+    expect(result.stdout).toContain('[fix the login bug]')
+  })
 })
 
 describe('resolve-code-oz.sh — npx fallback', () => {
@@ -164,6 +200,21 @@ describe('resolve-code-oz.sh — npx fallback', () => {
     expect(result.exitCode).toBe(0)
     // The exact pinned version string must appear in the npx invocation
     expect(result.stdout).toContain(pinnedVersion)
+  })
+
+  test('strips an empty-string positional before the npx invocation too', async () => {
+    const fakeDir = await makeFakeBinDir({
+      npx: `#!/bin/sh\nprintf 'ARGS:'\nfor a in "$@"; do printf '[%s]' "$a"; done\nprintf '\\n'\n`,
+    })
+
+    const result = await runResolver({
+      path: `${fakeDir}:${SYSTEM_BIN}`,
+      args: ['doctor', ''],
+    })
+
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toContain('[doctor]')
+    expect(result.stdout).not.toContain('[]')
   })
 })
 


### PR DESCRIPTION
## Why

Found by dogfooding the freshly-published plugin: `/code-oz-doctor` (and `/code-oz-init`) fail on every no-arg invocation.

Each command card renders `<subcommand> "$ARGUMENTS"`. With no user args, Claude Code substitutes an empty `$ARGUMENTS`, so the shell line becomes `... resolve-code-oz.sh doctor ""`. The engine's 0.21.1 subcommand dispatcher (which split `doctor` into `providers|tools|git|run`) treats `""` as a subcommand name and exits 1 (`unknown subcommand ''`). The engine handles **zero** positionals fine — the empty string is the problem.

| Invocation | Before |
|---|---|
| `doctor` | exit 0 ✓ |
| `doctor ""` | `unknown subcommand ''` → exit 1 ✗ |

`doctor`/`init` break every time; `run`/`resume` carry a latent trailing empty.

## What

Fix at the layer that introduces the artifact — the resolver strips empty-string positionals before both the PATH-exec and npx branches. An empty positional is never meaningful to code-oz, so `doctor ""` becomes `doctor`.

- Array form preserves args containing spaces; `${a[@]+"${a[@]}"}` keeps the empty-array expansion safe under `set -u` on **bash 3.2** (macOS default).
- RED-first: two empty-strip tests (PATH + npx branches) + a spaces-preservation guard.

## Verification

- On bash 3.2.57: `resolve-code-oz.sh doctor ""` now exits 0; `init ""` is byte-identical to `init` (its exit 1 is the legit "`.code-oz/` already exists" guard).
- 3815 offline tests pass; typecheck clean.

## Follow-up (not in this PR)

A carefully-scoped engine-level normalization — treat an empty subcommand token as absent, **not** a blanket argv filter (which would eat legitimate empty flag values like `run --message ""`) — would harden direct-CLI and other non-plugin callers. Tracked as a recommended follow-up.