### PR TITLE
ci(release): add npm trusted publishing workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,95 @@
+name: npm publish
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish, without the leading v"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: publish @tuel/code-oz
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve version
+        id: version
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -eu
+          if [ "${EVENT_NAME}" = "release" ]; then
+            VERSION="${RELEASE_TAG#v}"
+          else
+            VERSION="${INPUT_VERSION#v}"
+          fi
+          test -n "${VERSION}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release source
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.version.outputs.tag }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - name: Use npm 11
+        run: npm install -g npm@^11.10.0
+
+      - name: Check package version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -eu
+          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+          if [ "${PACKAGE_VERSION}" != "${VERSION}" ]; then
+            echo "package.json version ${PACKAGE_VERSION} does not match requested ${VERSION}" >&2
+            exit 1
+          fi
+
+      - name: Check matching GitHub release assets exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -eu
+          gh release view "${TAG}" --json tagName >/dev/null
+          gh release download "${TAG}" --pattern checksums.txt --dir /tmp/code-oz-release-check
+          test -s /tmp/code-oz-release-check/checksums.txt
+
+      - name: Skip if version is already published
+        id: published
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -eu
+          if npm view "@tuel/code-oz@${VERSION}" version --registry=https://registry.npmjs.org/ >/tmp/npm-version.txt 2>/dev/null; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            cat /tmp/npm-version.txt
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify package contents
+        if: steps.published.outputs.already != 'true'
+        run: npm pack --dry-run --json
+
+      - name: Publish package
+        if: steps.published.outputs.already != 'true'
+        run: npm publish --access public

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -1,6 +1,6 @@
 # Release readiness
 
-Current status as of 2026-06-14: this branch prepares `v0.21.2-alpha.0`. The latest published GitHub release and npm package are still `v0.21.1-alpha.0` / `0.21.1-alpha.0`; this branch needs a new release tag and matching GitHub release assets before it is available through normal install channels.
+Current status as of 2026-06-14: `v0.21.2-alpha.0` is published on GitHub release assets and Homebrew. npm `@tuel/code-oz@0.21.2-alpha.0` is package-ready but still pending publish authorization; the repo-side path is `.github/workflows/npm-publish.yml`, which uses npm trusted publishing with GitHub Actions OIDC.
 
 This page separates what is publishable today from what is manual, experimental, or future work.
 
@@ -9,8 +9,8 @@ This page separates what is publishable today from what is manual, experimental,
 | Surface | Package or path | Status | Notes |
 |---|---|---|---|
 | CLI binary | `src/cli.ts` compiled by `bun build --compile` | Publishable for macOS/Linux | GitHub release workflow builds per-arch tarballs and `checksums.txt`. Windows is not built. |
-| npm launcher | `@tuel/code-oz` | Publishable launcher package | `package.json.files` includes `npm-wrapper/`, `README.md`, and `LICENSE`. The wrapper downloads the matching GitHub release binary on first run. |
-| Homebrew formula | `docs/homebrew/code-oz.rb.template` | Manual tap bump | Render from release checksums, then commit to `omerakben/homebrew-code-oz`. |
+| npm launcher | `@tuel/code-oz` | Publish-ready, auth pending | `package.json.files` includes `npm-wrapper/`, `README.md`, and `LICENSE`. The wrapper downloads the matching GitHub release binary on first run. |
+| Homebrew formula | `docs/homebrew/code-oz.rb.template` | Published for `0.21.2-alpha.0` | Render from release checksums, then commit to `omerakben/homebrew-code-oz`. |
 | Claude Code plugin marketplace | `.claude-plugin/marketplace.json` | Repo-root marketplace metadata present | Contains `code-oz` engine wrapper plugin and advisory `code-oz-discipline` plugin. |
 | Agent skill bundle | `agent-skills/code-oz/` | Text-only integration surface | No executable. It teaches external agents how to drive the CLI without owning gates. |
 
@@ -43,6 +43,40 @@ Expected package shape for `npm pack --dry-run --json`: a small launcher tarball
 Do not publish npm before the GitHub release assets for the exact version exist, because the first npm invocation downloads `https://github.com/omerakben/code-oz/releases/download/v<version>/...`.
 
 `scripts/release/fresh-clone-smoke.sh` clones the current branch from git, so it validates committed `HEAD`, not uncommitted working-tree edits. Run it after the release-readiness patch is committed.
+
+## npm publish authorization
+
+Preferred path: use npm trusted publishing for `.github/workflows/npm-publish.yml`.
+
+Account-side setup on npmjs.com:
+
+1. Open `@tuel/code-oz` package settings.
+2. Add a trusted publisher:
+   - Provider: GitHub Actions
+   - Organization or user: `omerakben`
+   - Repository: `code-oz`
+   - Workflow filename: `npm-publish.yml`
+   - Allowed action: `npm publish`
+3. Run the workflow from GitHub Actions with `version=0.21.2-alpha.0`.
+
+CLI trigger after the workflow is on `main`:
+
+```sh
+gh workflow run npm-publish.yml -f version=0.21.2-alpha.0
+gh run watch --exit-status
+npm view @tuel/code-oz@0.21.2-alpha.0 version
+```
+
+Fallback path: publish locally after authenticating to npm:
+
+```sh
+npm login
+npm whoami
+npm publish --access public
+npm view @tuel/code-oz@0.21.2-alpha.0 version
+```
+
+Direct local publishing requires an npm account with publish rights to `@tuel/code-oz` and either account 2FA or a granular access token with publish rights and bypass 2FA enabled. The current machine is not authenticated to npm, so local publish returns `E401`.
 
 ## Plugin publishing checklist
 
@@ -103,4 +137,4 @@ Measured locally on 2026-06-14:
 - `code-oz-gui`: `bun install --frozen-lockfile`, `bun run typecheck`, `bun run lint`, `bun test tests/unit`, and `bun run build` pass.
 - Dogfood flows: first-run fake provider, `bun run demo:todo-cli`, `bun run demo:failure-gates`, `doctor providers`, `doctor tools`, `doctor git`, and `bench agent-gate --fixture todo-cli-real-tests --provider fake` pass.
 
-These are enough to call the docs/package/plugin/GUI release-prep patch ready for review. They are not enough to call a public release fully ready by themselves. A public release still needs the final tag workflow, matching GitHub release assets for the exact version, npm publish dry-run or publish authorization, Homebrew formula rendering from final checksums, and any live-provider checks relevant to the release scope.
+These are enough to call the docs/package/plugin/GUI release-prep patch ready for review. The public release is live through GitHub release assets, curl install, and Homebrew. npm still needs one authorization step through trusted publishing or an authenticated local publish.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
   },
   "homepage": "https://github.com/omerakben/code-oz",
   "bugs": "https://github.com/omerakben/code-oz/issues",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
   "keywords": [
     "ai",
     "coding-agent",


### PR DESCRIPTION
## Summary
- Add a tag-aware npm publish workflow that uses GitHub Actions OIDC for npm trusted publishing
- Add explicit public npm publish metadata to package.json
- Document the remaining npm account-side trusted publisher setup and local publish fallback

## Why
- The package is ready, but local npm publish is blocked by E401 because this machine is not authenticated to npm
- npm now recommends trusted publishing over long-lived tokens for CI/CD publishing

## Validation
- npm pack --dry-run --json
- npm publish --dry-run --access public
- npm pack --dry-run --json from v0.21.2-alpha.0 tag via temporary worktree
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/npm-publish.yml'); puts 'yaml ok'"\n- git diff --check\n\n## Risks / follow-ups\n- npm package settings still need a trusted publisher entry for workflow filename npm-publish.yml before the workflow can publish\n- actionlint is not installed locally, so GitHub CI is the workflow validation gate\n- If trusted publishing is not configured, fallback is npm login plus npm publish --access public from the release tag\n