### PR TITLE
ci(release): publish npm alphas under alpha tag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -92,4 +92,4 @@ jobs:
 
       - name: Publish package
         if: steps.published.outputs.already != 'true'
-        run: npm publish --access public
+        run: npm publish --access public --tag alpha

--- a/docs/RELEASE_READINESS.md
+++ b/docs/RELEASE_READINESS.md
@@ -65,6 +65,7 @@ CLI trigger after the workflow is on `main`:
 gh workflow run npm-publish.yml -f version=0.21.2-alpha.0
 gh run watch --exit-status
 npm view @tuel/code-oz@0.21.2-alpha.0 version
+npm view @tuel/code-oz dist-tags --json
 ```
 
 Fallback path: publish locally after authenticating to npm:
@@ -72,11 +73,11 @@ Fallback path: publish locally after authenticating to npm:
 ```sh
 npm login
 npm whoami
-npm publish --access public
+npm publish --access public --tag alpha
 npm view @tuel/code-oz@0.21.2-alpha.0 version
 ```
 
-Direct local publishing requires an npm account with publish rights to `@tuel/code-oz` and either account 2FA or a granular access token with publish rights and bypass 2FA enabled. The current machine is not authenticated to npm, so local publish returns `E401`.
+Direct local publishing requires an npm account with publish rights to `@tuel/code-oz` and either account 2FA or a granular access token with publish rights and bypass 2FA enabled. Alpha versions publish under the `alpha` dist-tag, not `latest`. The current machine is not authenticated to npm, so local publish returns `E401`.
 
 ## Plugin publishing checklist
 


### PR DESCRIPTION
## Summary
- Publish npm prerelease versions with the explicit alpha dist-tag
- Document alpha dist-tag verification in release readiness

## Why
- The first npm-publish workflow run reached the publish step and npm rejected the prerelease without an explicit tag:
  `npm error You must specify a tag using --tag when publishing a prerelease version.`

## Validation
- npm publish --dry-run --access public --tag alpha
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/npm-publish.yml'); puts 'yaml ok'"\n- git diff --check\n\n## Risks / follow-ups\n- After merge, rerun npm-publish.yml with version=0.21.2-alpha.0\n- If npm trusted publishing is not configured, the next failure should be npm OIDC/trusted-publisher authorization rather than package shape\n